### PR TITLE
github ci: linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint the code
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install pylint
+        run: pip install pylint
+
+      - name: Lint
+        run: pylint $(git ls-files '*.py')

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+.*_cache
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+venv/


### PR DESCRIPTION
Added CI workflow for linting (using [pylint](https://www.pylint.org/)).

Currently fails, but perhaps it's a good start to add it to CI?

Run the linter manually:

```bash
pip install pylint
pylint $(git ls-files '*.py')
```