### PR TITLE
Add types for ABIs

### DIFF
--- a/mev_inspect/abi.py
+++ b/mev_inspect/abi.py
@@ -1,0 +1,20 @@
+import json
+from typing import Optional
+
+from pydantic import parse_obj_as
+
+from mev_inspect.config import load_config
+from mev_inspect.schemas import ABI
+
+
+ABI_CONFIG_KEY = "ABI"
+
+config = load_config()
+
+
+def get_abi(abi_name: str) -> Optional[ABI]:
+    if abi_name in config[ABI_CONFIG_KEY]:
+        abi_json = json.loads(config[ABI_CONFIG_KEY][abi_name])
+        return parse_obj_as(ABI, abi_json)
+
+    return None

--- a/mev_inspect/schemas/__init__.py
+++ b/mev_inspect/schemas/__init__.py
@@ -1,1 +1,2 @@
+from .abi import ABI
 from .blocks import Block, BlockCall, BlockCallType

--- a/mev_inspect/schemas/abi.py
+++ b/mev_inspect/schemas/abi.py
@@ -6,8 +6,6 @@ from hexbytes import HexBytes
 from pydantic import BaseModel
 from web3 import Web3
 
-from .utils import CamelModel
-
 
 class ABIDescriptionType(str, Enum):
     function = "function"
@@ -25,8 +23,8 @@ NON_FUNCTION_DESCRIPTION_TYPES = Union[
 ]
 
 
-class ABIDescriptionInput(CamelModel):
-    internal_type: str
+class ABIDescriptionInput(BaseModel):
+    type: str
 
 
 class ABIGenericDescription(BaseModel):
@@ -43,8 +41,7 @@ class ABIFunctionDescription(BaseModel):
         return Web3.sha3(text=signature)[0:4]
 
     def get_signature(self) -> str:
-        joined_input_types = ",".join(input.internal_type for input in self.inputs)
-
+        joined_input_types = ",".join(input.type for input in self.inputs)
         return f"{self.name}({joined_input_types})"
 
 

--- a/mev_inspect/schemas/abi.py
+++ b/mev_inspect/schemas/abi.py
@@ -1,0 +1,52 @@
+from enum import Enum
+from typing import List, Union
+from typing_extensions import Literal
+
+from hexbytes import HexBytes
+from pydantic import BaseModel
+from web3 import Web3
+
+from .utils import CamelModel
+
+
+class ABIDescriptionType(str, Enum):
+    function = "function"
+    constructor = "constructor"
+    fallback = "fallback"
+    event = "event"
+    receive = "receive"
+
+
+NON_FUNCTION_DESCRIPTION_TYPES = Union[
+    Literal[ABIDescriptionType.constructor],
+    Literal[ABIDescriptionType.fallback],
+    Literal[ABIDescriptionType.event],
+    Literal[ABIDescriptionType.receive],
+]
+
+
+class ABIDescriptionInput(CamelModel):
+    internal_type: str
+
+
+class ABIGenericDescription(BaseModel):
+    type: NON_FUNCTION_DESCRIPTION_TYPES
+
+
+class ABIFunctionDescription(BaseModel):
+    type: Literal[ABIDescriptionType.function]
+    name: str
+    inputs: List[ABIDescriptionInput]
+
+    def get_selector(self) -> HexBytes:
+        signature = self.get_signature()
+        return Web3.sha3(text=signature)[0:4]
+
+    def get_signature(self) -> str:
+        joined_input_types = ",".join(input.internal_type for input in self.inputs)
+
+        return f"{self.name}({joined_input_types})"
+
+
+ABIDescription = Union[ABIFunctionDescription, ABIGenericDescription]
+ABI = List[ABIDescription]


### PR DESCRIPTION
Adds some typing around loading ABIs
Also adds convenience functions for creating function signatures and selectors
I only added the fields I'm using so far. More can be added as needed

## Testing
Script
```
from mev_inspect.abi import get_abi


def main():
    router_abi = get_abi("UniswapV2Router")
    add_liquidity_function = router_abi[2]
    print(add_liquidity_function.name)
    print(add_liquidity_function.get_signature())
    print(add_liquidity_function.get_selector().hex())


if __name__ == "__main__":
    main()
```
Output
```
addLiquidity
addLiquidity(address,address,uint256,uint256,uint256,uint256,address,uint256)
0xe8e33700
```