### PR TITLE
Inspect args fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ compose ...` calls.  Check `docker compose help` for more tools available
 Inspection is the only simplified api available through poetry at the moment
 with a more generalized api on the horizon.
 
-Inspect scripts must have `-script`, `-block_number` and `-rpc` arguments.
+Inspect scripts must have `-s/--script`, `-b/--block-number` and `-r/-rpc` arguments.
 Using the uniswap inspect from `./examples`
 ```
-poetry run inspect -script ./examples/uniswap_inspect.py -block_number 11931271 \
-                   -rpc 'http://111.11.11.111:8545'
+poetry run inspect -s ./examples/uniswap_inspect.py -b 11931271 \
+                   -r 'http://111.11.11.111:8545'
 ```
 
 Generalized user defined scripts can still be run through the docker interface as
@@ -62,7 +62,7 @@ poetry run stop # shutsdown all services or just ctrl + c if foreground
 poetry run build # rebuilds containers
 poetry run attach # enters the mev-inspect container in interactive mode
 # launches inspection script
-poetry run inspect -script ... -block_number ... -rpc ...
+poetry run inspect -s <script> -b <block number> -r <rpc>
 ```
 
 

--- a/scripts/docker.py
+++ b/scripts/docker.py
@@ -26,10 +26,12 @@ def attach():
 
 
 @click.command()
-@click.option("-script", help="inspect script", default="./examples/uniswap_inspect.py")
-@click.option("-block_num", help="block number to inspect", default=11931271)
-@click.option("-rpc", help="rpc address", default="http://111.11.11.111:8545")
-def inspect(script: str, block_num: int, rpc: str):
+@click.option(
+    "-s", "--script", help="inspect script", default="./examples/uniswap_inspect.py"
+)
+@click.option("-b", "--block-num", help="block number to inspect", default="11931271")
+@click.option("-r", "--rpc", help="rpc address", default="http://111.11.11.111:8545")
+def inspect(script: str, block_num: str, rpc: str):
     """Runs mev-inspect scripts through docker services"""
     check_call(
         [
@@ -39,7 +41,9 @@ def inspect(script: str, block_num: int, rpc: str):
             "mev-inspect",
             "python",
             script,
-            f"-block_number {block_num}",
-            f"-rpc {rpc}",
+            "-block_number",
+            block_num,
+            "-rpc",
+            rpc,
         ]
     )


### PR DESCRIPTION
Block number and rpc are now correctly listed as separate arguments.  Added shorthands for optional args as well i.e., -b for --block-num