### PR TITLE
Replace existing traces when inspecting a block

### DIFF
--- a/alembic/versions/c5da44eb072c_add_index_for_classified_traces_block_.py
+++ b/alembic/versions/c5da44eb072c_add_index_for_classified_traces_block_.py
@@ -1,0 +1,24 @@
+"""Add index for classified_traces.block_number
+
+Revision ID: c5da44eb072c
+Revises: 0660432b9840
+Create Date: 2021-07-30 17:37:27.335475
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c5da44eb072c'
+down_revision = '0660432b9840'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('i_block_number', 'classified_traces', ['block_number'])
+
+
+def downgrade():
+    op.drop_index('i_block_number', 'classified_traces')

--- a/mev_inspect/crud/classified_traces.py
+++ b/mev_inspect/crud/classified_traces.py
@@ -5,6 +5,17 @@ from mev_inspect.models.classified_traces import ClassifiedTraceModel
 from mev_inspect.schemas.classified_traces import ClassifiedTrace
 
 
+def delete_classified_traces_for_block(
+    db_session, block_number: int,
+) -> None:
+    (db_session.query(ClassifiedTraceModel)
+       .filter(ClassifiedTraceModel.block_number == block_number)
+       .delete()
+    )
+
+    db_session.commit()
+
+
 def write_classified_traces(
     db_session,
     classified_traces: List[ClassifiedTrace],

--- a/scripts/inspect_block.py
+++ b/scripts/inspect_block.py
@@ -4,7 +4,10 @@ import click
 from web3 import Web3
 
 from mev_inspect import block
-from mev_inspect.crud.classified_traces import write_classified_traces
+from mev_inspect.crud.classified_traces import (
+    delete_classified_traces_for_block,
+    write_classified_traces,
+)
 from mev_inspect.db import get_session
 from mev_inspect.classifier_specs import CLASSIFIER_SPECS
 from mev_inspect.trace_classifier import TraceClassifier
@@ -32,6 +35,7 @@ def inspect_block(block_number: int, rpc: str):
     print(f"Returned {len(classified_traces)} classified traces")
 
     db_session = get_session()
+    delete_classified_traces_for_block(db_session, block_number)
     write_classified_traces(db_session, classified_traces)
     db_session.close()
 


### PR DESCRIPTION
Right now you get a conflict duplicate traces error from running inspect for the same block twice without manually deleting from the database

This changes the default script to delete all before writing

Also adds an index to make that fast

Upgrade to that latest version of the DB with
```
poetry run exec alembic upgrade head
```

## Testing
Run inspect multiple times and verify it doesn't complain