### PR TITLE
Add middleware to retry with backoff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tests
+cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
       - id: 'mypy'
         additional_dependencies:
           - 'pydantic'
+          - 'types-requests'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY . /app
 # easter eggs 😝
 RUN echo "PS1='🕵️:\[\033[1;36m\]\h \[\033[1;34m\]\W\[\033[0;35m\]\[\033[1;36m\]$ \[\033[0m\]'" >> ~/.bashrc
 
-CMD ["/bin/bash"]
+CMD [ "python", "run.py"]

--- a/Tiltfile
+++ b/Tiltfile
@@ -11,7 +11,7 @@ k8s_yaml(secret_from_dict("mev-inspect-db-credentials", inputs = {
     "password": "password",
 }))
 
-docker_build('mev-inspect', '.',
+docker_build('mev-inspect-py', '.',
     live_update=[
         sync('.', '/app'),
         run('cd /app && poetry install',

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -16,9 +16,8 @@ spec:
     spec:
       containers:
       - name: mev-inspect
-        image: mev-inspect:latest
-        command: [ "/bin/bash", "-c", "--" ]
-        args: [ "while true; do sleep 30; done;" ]
+        image: mev-inspect-py
+        command: [ "python", "run.py"]
         env:
         - name: POSTGRES_USER
           valueFrom:
@@ -30,6 +29,8 @@ spec:
             secretKeyRef:
               name: mev-inspect-db-credentials
               key: password
+        - name: POSTGRES_HOST
+          value: postgresql
         livenessProbe:
           exec:
             command:

--- a/mev_inspect/db.py
+++ b/mev_inspect/db.py
@@ -7,9 +7,9 @@ from sqlalchemy.orm import sessionmaker
 def get_sqlalchemy_database_uri():
     username = os.getenv("POSTGRES_USER")
     password = os.getenv("POSTGRES_PASSWORD")
-    server = "postgresql"
+    host = os.getenv("POSTGRES_HOST")
     db_name = "mev_inspect"
-    return f"postgresql://{username}:{password}@{server}/{db_name}"
+    return f"postgresql://{username}:{password}@{host}/{db_name}"
 
 
 def get_engine():

--- a/mev_inspect/retry.py
+++ b/mev_inspect/retry.py
@@ -1,0 +1,59 @@
+import time
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Type,
+)
+
+from requests.exceptions import (
+    ConnectionError,
+    HTTPError,
+    Timeout,
+    TooManyRedirects,
+)
+from web3 import Web3
+from web3.middleware.exception_retry_request import check_if_retry_on_failure
+from web3.types import (
+    RPCEndpoint,
+    RPCResponse,
+)
+
+
+def exception_retry_with_backoff_middleware(
+    make_request: Callable[[RPCEndpoint, Any], RPCResponse],
+    web3: Web3,  # pylint: disable=unused-argument
+    errors: Collection[Type[BaseException]],
+    retries: int = 5,
+    backoff_time_seconds: float = 0.1,
+) -> Callable[[RPCEndpoint, Any], RPCResponse]:
+    """
+    Creates middleware that retries failed HTTP requests. Is a default
+    middleware for HTTPProvider.
+    """
+
+    def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+        if check_if_retry_on_failure(method):
+            for i in range(retries):
+                try:
+                    return make_request(method, params)
+                # https://github.com/python/mypy/issues/5349
+                except errors:  # type: ignore
+                    if i < retries - 1:
+                        time.sleep(backoff_time_seconds)
+                        continue
+                    else:
+                        raise
+            return None
+        else:
+            return make_request(method, params)
+
+    return middleware
+
+
+def http_retry_with_backoff_request_middleware(
+    make_request: Callable[[RPCEndpoint, Any], Any], web3: Web3
+) -> Callable[[RPCEndpoint, Any], Any]:
+    return exception_retry_with_backoff_middleware(
+        make_request, web3, (ConnectionError, HTTPError, Timeout, TooManyRedirects)
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ build-backend = "poetry.core.masonry.api"
 lint = 'scripts.poetry.dev_tools:lint'
 test = 'scripts.poetry.dev_tools:test'
 isort = 'scripts.poetry.dev_tools:isort'
-mypy = 'scripts.poetry.dev_tools:mypy'
 black = 'scripts.poetry.dev_tools:black'
 pre_commit = 'scripts.poetry.dev_tools:pre_commit'
 start = 'scripts.poetry.docker:start'

--- a/run.py
+++ b/run.py
@@ -1,0 +1,5 @@
+import time
+
+if __name__ == "__main__":
+    while True:
+        time.sleep(30)


### PR DESCRIPTION
The current http middleware in web3.py has retry logic but those retries are immediate.

We've been still seeing timeouts even with this built in retry logic.

To avoid destroying the RPC endpoint and get less timeouts, this adds a 100 ms delay between requests (configurable)

Also includes a couple tiny things
- Switch to a run script instead of a bash infinite loop
- Break postgres host out into an environment variable (needed for production deploy)