### PR TITLE
Don't start block listener on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY . /app
 # easter eggs 😝
 RUN echo "PS1='🕵️:\[\033[1;36m\]\h \[\033[1;34m\]\W\[\033[0;35m\]\[\033[1;36m\]$ \[\033[0m\]'" >> ~/.bashrc
 
-ENTRYPOINT [ "/app/run.sh"]
+ENTRYPOINT [ "/app/entrypoint.sh"]

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,7 +19,7 @@ k8s_yaml(secret_from_dict("mev-inspect-db-credentials", inputs = {
 }))
 
 docker_build_with_restart("mev-inspect-py", ".",
-    entrypoint="/app/run.sh",
+    entrypoint="/app/entrypoint.sh",
     live_update=[
         sync(".", "/app"),
         run("cd /app && poetry install",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python loop.py

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: mev-inspect
         image: mev-inspect-py
-        command: [ "/app/run.sh" ]
+        command: [ "/app/entrypoint.sh" ]
         env:
         - name: POSTGRES_USER
           valueFrom:

--- a/listener
+++ b/listener
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -e
+
+NAME=listener
+PIDFILE=/var/run/$NAME.pid
+DAEMON=/root/.poetry/bin/poetry
+DAEMON_OPTS="run python listener.py"
+
+case "$1" in
+  start)
+        echo -n "Starting daemon: "$NAME
+	start-stop-daemon \
+        --background \
+        --chdir /app \
+        --start \
+        --quiet \
+        --pidfile $PIDFILE \
+        --make-pidfile \
+        --startas $DAEMON -- $DAEMON_OPTS
+        echo "."
+	;;
+  stop)
+        echo -n "Stopping daemon: "$NAME
+	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+        echo "."
+	;;
+  restart)
+        echo -n "Restarting daemon: "$NAME
+	start-stop-daemon --stop --quiet --oknodo --retry 30 --pidfile $PIDFILE
+	start-stop-daemon \
+        --background \
+        --chdir /app \
+        --start \
+        --quiet \
+        --pidfile $PIDFILE \
+        --make-pidfile \
+        --startas $DAEMON -- $DAEMON_OPTS
+        echo "."
+    ;;
+
+  *)
+	echo "Usage: "$1" {start|stop|restart}"
+	exit 1
+esac
+
+exit 0

--- a/listener.py
+++ b/listener.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import signal
 import time
 
 from web3 import Web3
@@ -13,30 +12,11 @@ from mev_inspect.crud.latest_block_update import (
 from mev_inspect.db import get_session
 from mev_inspect.inspect_block import inspect_block
 from mev_inspect.provider import get_base_provider
+from mev_inspect.signal_handler import GracefulKiller
 
 
-logging.basicConfig(filename="app.log", level=logging.INFO)
+logging.basicConfig(filename="listener.log", level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-class GracefulKiller:
-    """
-    handle sigint / sigterm gracefully
-    taken from https://stackoverflow.com/a/31464349
-    """
-
-    signal_names = {signal.SIGINT: "SIGINT", signal.SIGTERM: "SIGTERM"}
-
-    def __init__(self):
-        self.kill_now = False
-        signal.signal(signal.SIGINT, self.exit_gracefully)
-        signal.signal(signal.SIGTERM, self.exit_gracefully)
-
-    def exit_gracefully(self, signum, frame):  # pylint: disable=unused-argument
-        signal_name = self.signal_names[signum]
-        logger.info(f"Received {signal_name} signal")
-        logger.info("Cleaning up resources. End of process")
-        self.kill_now = True
 
 
 def run():

--- a/loop.py
+++ b/loop.py
@@ -1,0 +1,22 @@
+import logging
+import time
+
+from mev_inspect.signal_handler import GracefulKiller
+
+
+logging.basicConfig(filename="loop.log", level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def run():
+    logger.info("Starting...")
+
+    killer = GracefulKiller()
+    while not killer.kill_now:
+        time.sleep(1)
+
+    logger.info("Stopping...")
+
+
+if __name__ == "__main__":
+    run()

--- a/mev_inspect/signal_handler.py
+++ b/mev_inspect/signal_handler.py
@@ -1,0 +1,24 @@
+import logging
+import signal
+
+logger = logging.getLogger(__name__)
+
+
+class GracefulKiller:
+    """
+    handle sigint / sigterm gracefully
+    taken from https://stackoverflow.com/a/31464349
+    """
+
+    signal_names = {signal.SIGINT: "SIGINT", signal.SIGTERM: "SIGTERM"}
+
+    def __init__(self):
+        self.kill_now = False
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+    def exit_gracefully(self, signum, frame):  # pylint: disable=unused-argument
+        signal_name = self.signal_names[signum]
+        logger.info(f"Received {signal_name} signal")
+        logger.info("Cleaning up resources. End of process")
+        self.kill_now = True

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python run.py


### PR DESCRIPTION
Currently when the mev inspect container starts it starts immediately listening for new blocks and writing them to the DB

For local dev, this is usually not what we want

This PR changes back to have a container that just runs an infinite loop

To listen for new blocks, there's a script `listener` which supports
```
listener start
listener stop
listener restart
```
for looking for new blocks and writing them to the DB

more coming in how this all fits together w/ README updates