### PR TITLE
Adjust arbitrage calculation logic

### DIFF
--- a/tests/test_arbitrage_integration.py
+++ b/tests/test_arbitrage_integration.py
@@ -23,4 +23,4 @@ def test_arbitrage_real_block():
     assert (
         arbitrage.profit_token_address == "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
     )
-    assert arbitrage.profit_amount == 53560707941943273628
+    assert arbitrage.profit_amount == 750005273675102326

--- a/tests/test_arbitrages.py
+++ b/tests/test_arbitrages.py
@@ -1,4 +1,7 @@
-from mev_inspect.arbitrages import get_arbitrages
+import itertools
+from typing import List
+
+from mev_inspect.arbitrages import get_arbitrages, _order_swaps_by_trace_order
 from mev_inspect.schemas.swaps import Swap
 from mev_inspect.swaps import (
     UNISWAP_V2_PAIR_ABI_NAME,
@@ -158,3 +161,49 @@ def test_three_pool_arbitrage(get_transaction_hashes, get_addresses):
     assert arbitrage.start_amount == first_token_in_amount
     assert arbitrage.end_amount == first_token_out_amount
     assert arbitrage.profit_amount == first_token_out_amount - first_token_in_amount
+
+
+def test_order_swaps_by_trace_order():
+    trace_address_0 = []
+    trace_address_1 = [0]
+    trace_address_2 = [1]
+    trace_address_3 = [1, 1]
+    trace_address_4 = [2, 1, 3]
+    trace_address_5 = [2, 2]
+
+    permutated_trace_addresses: List[List[int]] = itertools.permutations(
+        [
+            trace_address_0,
+            trace_address_1,
+            trace_address_2,
+            trace_address_3,
+            trace_address_4,
+            trace_address_5,
+        ]
+    )
+
+    for trace_addresses in permutated_trace_addresses:
+        swaps: List[Swap] = []
+        for trace_address in trace_addresses:
+            swap = Swap(
+                abi_name=UNISWAP_V3_POOL_ABI_NAME,
+                transaction_hash="0xfake",
+                block_number=0,
+                trace_address=trace_address,
+                pool_address="0xfake",
+                from_address="0xfake",
+                to_address="0xfake",
+                token_in_address="0xfake",
+                token_in_amount=1,
+                token_out_address="0xfake",
+                token_out_amount=1,
+            )
+            swaps.append(swap)
+        ordered_swaps = _order_swaps_by_trace_order(swaps)
+
+        assert ordered_swaps[0].trace_address == trace_address_0
+        assert ordered_swaps[1].trace_address == trace_address_1
+        assert ordered_swaps[2].trace_address == trace_address_2
+        assert ordered_swaps[3].trace_address == trace_address_3
+        assert ordered_swaps[4].trace_address == trace_address_4
+        assert ordered_swaps[5].trace_address == trace_address_5


### PR DESCRIPTION
Arbitrage logic changes
- Arbitrage logic was [previously dependent](https://github.com/flashbots/mev-inspect-py/blob/main/mev_inspect/arbitrages.py#L89) on pool address chaining. I believe (potentially incorrectly) that this is only the case in uni pools that are swapped via the uni-v2/v3 routers. This approach doesn't work for the case of an arb contract executing the swaps individually against the pools nor other AMMs which do not have the same router paradigm (ex: balancer). 
-[Example tx of scenario described](https://etherscan.io/tx/0xbbb549f93a99a99f4c7aaa6b9c93a1f5f670d13b483be3487b942720c6f08d6e)
- Additionally this adjusts the arb detection logic to sort by transfers upfront (via swap.trace_address)

Testing
- Unit test for ordering by `swap.trace_address`
- Existing arb tests work with new logic
- Spot tested against txs picked up by mev-inspect-rs across balancer and uni in single tx 
- Integration test (`tests/test_arbitrage_integration.py`) was adjusted to a profit amount of .75ETH from 52ETH. I believe this is the correct number unless I'm missing something about how this is calculated ([etherscan of test tx](https://etherscan.io/tx/0x448245bf1a507b73516c4eeee01611927dada6610bf26d403012f2e66800d8f0))
