### PR TITLE
Add DB migration to support ETH transfers

### DIFF
--- a/alembic/versions/3beffc1ec99c_make_transfer_token_address_nullable.py
+++ b/alembic/versions/3beffc1ec99c_make_transfer_token_address_nullable.py
@@ -1,0 +1,27 @@
+"""Make transfer and swap token addresses nullable
+
+Revision ID: 3beffc1ec99c
+Revises: c8363617aa07
+Create Date: 2021-10-08 16:27:52.058695
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3beffc1ec99c"
+down_revision = "c8363617aa07"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("transfers", "token_address", nullable=True)
+    op.alter_column("swaps", "token_in_address", nullable=True)
+    op.alter_column("swaps", "token_out_address", nullable=True)
+
+
+def downgrade():
+    op.alter_column("transfers", "token_address", nullable=False)
+    op.alter_column("swaps", "token_in_address", nullable=False)
+    op.alter_column("swaps", "token_out_address", nullable=False)


### PR DESCRIPTION
Represents an ETH transfer in the DB as a transfer where the token address is null

Would love feedback on this or alternative approaches if people have suggestions

I like the approach because it means all of our existing code can work the same

I don't like that it's not hyper explicit (token_address null implying eth)