### PR TITLE
Add `mev` command for easy inspect use

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -16,6 +16,7 @@ k8s_yaml(configmap_from_dict("mev-inspect-rpc", inputs = {
 k8s_yaml(secret_from_dict("mev-inspect-db-credentials", inputs = {
     "username" : "postgres",
     "password": "password",
+    "host": "postgresql",
 }))
 
 docker_build_with_restart("mev-inspect-py", ".",

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -19,6 +19,11 @@ spec:
         image: mev-inspect-py
         command: [ "/app/entrypoint.sh" ]
         env:
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: mev-inspect-db-credentials
+              key: host
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
@@ -29,8 +34,6 @@ spec:
             secretKeyRef:
               name: mev-inspect-db-credentials
               key: password
-        - name: POSTGRES_HOST
-          value: postgresql
         - name: RPC_URL
           valueFrom:
             configMapKeyRef:

--- a/mev
+++ b/mev
@@ -2,9 +2,27 @@
 
 set -e
 
+DB_NAME=mev_inspect
+
+function get_kube_db_secret(){
+    kubectl get secrets mev-inspect-db-credentials -o jsonpath="{.data.$1}" | base64 --decode
+}
+
+function db(){
+    host=$(get_kube_db_secret "host")
+    username=$(get_kube_db_secret "username")
+    password=$(get_kube_db_secret "password")
+
+    kubectl run -i --rm --tty postgres-client \
+        --env="PGPASSWORD=$password"  \
+        --image=jbergknoff/postgresql-client \
+        -- $DB_NAME --host=$host --user=$username
+}
+
 case "$1" in
-  backfill)
-        echo "Running backfill from block $2 to block $3"
+  db)
+        echo "Connecting to $DB_NAME"
+        db
 	;;
   inspect)
         block_number=$2


### PR DESCRIPTION
Supports a few commands

Inspecting a block
```
./mev inspect 12412732
```

Running tests
```
./mev test
```

And connecting to the DB 
```
./mev db
```

To support connecting to the DB locally and in prod the same, this also moves the host to the secret configmap with username and password