### PR TITLE
Change classified_traces and miner_payments primary keys to begin with block number

### DIFF
--- a/alembic/versions/04a3bb3740c3_change_miner_payments_and_transfers_.py
+++ b/alembic/versions/04a3bb3740c3_change_miner_payments_and_transfers_.py
@@ -1,0 +1,55 @@
+"""Change miner payments and transfers primary keys to include block number
+
+Revision ID: 04a3bb3740c3
+Revises: a10d68643476
+Create Date: 2021-11-02 22:42:01.702538
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "04a3bb3740c3"
+down_revision = "a10d68643476"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # transfers
+    op.execute("ALTER TABLE transfers DROP CONSTRAINT transfers_pkey")
+    op.create_primary_key(
+        "transfers_pkey",
+        "transfers",
+        ["block_number", "transaction_hash", "trace_address"],
+    )
+    op.drop_index("ix_transfers_block_number")
+
+    # miner_payments
+    op.execute("ALTER TABLE miner_payments DROP CONSTRAINT miner_payments_pkey")
+    op.create_primary_key(
+        "miner_payments_pkey",
+        "miner_payments",
+        ["block_number", "transaction_hash"],
+    )
+    op.drop_index("ix_block_number")
+
+
+def downgrade():
+    # transfers
+    op.execute("ALTER TABLE transfers DROP CONSTRAINT transfers_pkey")
+    op.create_index("ix_transfers_block_number", "transfers", ["block_number"])
+    op.create_primary_key(
+        "transfers_pkey",
+        "transfers",
+        ["transaction_hash", "trace_address"],
+    )
+
+    # miner_payments
+    op.execute("ALTER TABLE miner_payments DROP CONSTRAINT miner_payments_pkey")
+    op.create_index("ix_block_number", "miner_payments", ["block_number"])
+    op.create_primary_key(
+        "miner_payments_pkey",
+        "miner_payments",
+        ["transaction_hash"],
+    )

--- a/alembic/versions/a10d68643476_change_classified_traces_primary_key_to_.py
+++ b/alembic/versions/a10d68643476_change_classified_traces_primary_key_to_.py
@@ -1,0 +1,35 @@
+"""Change classified traces primary key to include block number
+
+Revision ID: a10d68643476
+Revises: 3417f49d97b3
+Create Date: 2021-11-02 22:03:26.312317
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a10d68643476"
+down_revision = "3417f49d97b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE classified_traces DROP CONSTRAINT classified_traces_pkey")
+    op.create_primary_key(
+        "classified_traces_pkey",
+        "classified_traces",
+        ["block_number", "transaction_hash", "trace_address"],
+    )
+    op.drop_index("i_block_number")
+
+
+def downgrade():
+    op.execute("ALTER TABLE classified_traces DROP CONSTRAINT classified_traces_pkey")
+    op.create_index("i_block_number", "classified_traces", ["block_number"])
+    op.create_primary_key(
+        "classified_traces_pkey",
+        "classified_traces",
+        ["transaction_hash", "trace_address"],
+    )


### PR DESCRIPTION
Initially this PR was intended to remove the need for a second index on `block_number` to speed up inserts, but it ended up solving much more.

In backfills with large parallelism (ex: ~50) we saw that most of the time workers were waiting on DB locks

Specifically, the largest delay was caused by ExclusiveLocks taken on INSERT to our larger tables (swaps, classified_traces, miner_payments)

Switching over to these index structures dramatically reduced the time taken by these ExclusiveLocks

I don't fully know why unfortunately

Presumably it's much faster to check uniqueness and update indices starting with block number since:
- We've just deleted all entries for the block before this write
- All inserts share the same block number

Compared to using transaction hashes where the checks and updates are scattered around the sorted index