### PR TITLE
Support asyncio in listener

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,10 +1,8 @@
-import asyncio
 import os
-import signal
-from functools import wraps
 
 import click
 
+from mev_inspect.concurrency import coro
 from mev_inspect.db import get_inspect_session, get_trace_session
 from mev_inspect.inspector import MEVInspector
 
@@ -14,25 +12,6 @@ RPC_URL_ENV = "RPC_URL"
 @click.group()
 def cli():
     pass
-
-
-def coro(f):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        loop = asyncio.get_event_loop()
-
-        def cancel_task_callback():
-            for task in asyncio.all_tasks():
-                task.cancel()
-
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, cancel_task_callback)
-        try:
-            loop.run_until_complete(f(*args, **kwargs))
-        finally:
-            loop.run_until_complete(loop.shutdown_asyncgens())
-
-    return wrapper
 
 
 @cli.command()

--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 import click
 
+from mev_inspect.db import get_inspect_session, get_trace_session
 from mev_inspect.inspector import MEVInspector
 
 RPC_URL_ENV = "RPC_URL"
@@ -39,7 +40,10 @@ def coro(f):
 @click.option("--rpc", default=lambda: os.environ.get(RPC_URL_ENV, ""))
 @coro
 async def inspect_block_command(block_number: int, rpc: str):
-    inspector = MEVInspector(rpc=rpc)
+    inspect_db_session = get_inspect_session()
+    trace_db_session = get_trace_session()
+
+    inspector = MEVInspector(rpc, inspect_db_session, trace_db_session)
     await inspector.inspect_single_block(block=block_number)
 
 
@@ -48,7 +52,10 @@ async def inspect_block_command(block_number: int, rpc: str):
 @click.option("--rpc", default=lambda: os.environ.get(RPC_URL_ENV, ""))
 @coro
 async def fetch_block_command(block_number: int, rpc: str):
-    inspector = MEVInspector(rpc=rpc)
+    inspect_db_session = get_inspect_session()
+    trace_db_session = get_trace_session()
+
+    inspector = MEVInspector(rpc, inspect_db_session, trace_db_session)
     block = await inspector.create_from_block(block_number=block_number)
     print(block.json())
 
@@ -74,8 +81,13 @@ async def inspect_many_blocks_command(
     max_concurrency: int,
     request_timeout: int,
 ):
+    inspect_db_session = get_inspect_session()
+    trace_db_session = get_trace_session()
+
     inspector = MEVInspector(
-        rpc=rpc,
+        rpc,
+        inspect_db_session,
+        trace_db_session,
         max_concurrency=max_concurrency,
         request_timeout=request_timeout,
     )

--- a/mev_inspect/block.py
+++ b/mev_inspect/block.py
@@ -11,6 +11,7 @@ from mev_inspect.fees import fetch_base_fee_per_gas
 from mev_inspect.schemas.blocks import Block
 from mev_inspect.schemas.receipts import Receipt
 from mev_inspect.schemas.traces import Trace, TraceType
+from mev_inspect.utils import hex_to_int
 
 
 cache_directory = "./cache"
@@ -18,8 +19,13 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def get_latest_block_number(w3: Web3) -> int:
-    return int(w3.eth.get_block("latest")["number"])
+async def get_latest_block_number(base_provider) -> int:
+    latest_block = await base_provider.make_request(
+        "eth_getBlockByNumber",
+        ["latest", False],
+    )
+
+    return hex_to_int(latest_block["result"]["number"])
 
 
 async def create_from_block_number(

--- a/mev_inspect/concurrency.py
+++ b/mev_inspect/concurrency.py
@@ -1,0 +1,22 @@
+import asyncio
+import signal
+from functools import wraps
+
+
+def coro(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+
+        def cancel_task_callback():
+            for task in asyncio.all_tasks():
+                task.cancel()
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, cancel_task_callback)
+        try:
+            loop.run_until_complete(f(*args, **kwargs))
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+
+    return wrapper

--- a/mev_inspect/inspector.py
+++ b/mev_inspect/inspector.py
@@ -3,13 +3,14 @@ import logging
 import sys
 import traceback
 from asyncio import CancelledError
+from typing import Optional
 
+from sqlalchemy import orm
 from web3 import Web3
 from web3.eth import AsyncEth
 
 from mev_inspect.block import create_from_block_number
 from mev_inspect.classifiers.trace import TraceClassifier
-from mev_inspect.db import get_inspect_session, get_trace_session
 from mev_inspect.inspect_block import inspect_block
 from mev_inspect.provider import get_base_provider
 
@@ -21,11 +22,13 @@ class MEVInspector:
     def __init__(
         self,
         rpc: str,
+        inspect_db_session: orm.Session,
+        trace_db_session: Optional[orm.Session],
         max_concurrency: int = 1,
         request_timeout: int = 300,
     ):
-        self.inspect_db_session = get_inspect_session()
-        self.trace_db_session = get_trace_session()
+        self.inspect_db_session = inspect_db_session
+        self.trace_db_session = trace_db_session
         self.base_provider = get_base_provider(rpc, request_timeout=request_timeout)
         self.w3 = Web3(self.base_provider, modules={"eth": (AsyncEth,)}, middlewares=[])
         self.trace_classifier = TraceClassifier()


### PR DESCRIPTION
Currently the cli and backfills support async operations but the listener doesn't

This makes the changes necessary for the listener to run as well

Solves https://github.com/flashbots/mev-inspect-py/issues/122