### PR TITLE
Only set base logging from entry points

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,6 @@
+import logging
 import os
+import sys
 
 import click
 
@@ -7,6 +9,8 @@ from mev_inspect.db import get_inspect_session, get_trace_session
 from mev_inspect.inspector import MEVInspector
 
 RPC_URL_ENV = "RPC_URL"
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 
 @click.group()

--- a/listener.py
+++ b/listener.py
@@ -16,7 +16,7 @@ from mev_inspect.provider import get_base_provider
 from mev_inspect.signal_handler import GracefulKiller
 
 
-logging.basicConfig(filename="listener.log", level=logging.INFO)
+logging.basicConfig(filename="listener.log", filemode="a", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # lag to make sure the blocks we see are settled

--- a/mev_inspect/block.py
+++ b/mev_inspect/block.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-import sys
-from pathlib import Path
 from typing import List, Optional
 
 from sqlalchemy import orm
@@ -14,8 +12,6 @@ from mev_inspect.schemas.traces import Trace, TraceType
 from mev_inspect.utils import hex_to_int
 
 
-cache_directory = "./cache"
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -171,17 +167,3 @@ def get_transaction_hashes(calls: List[Trace]) -> List[str]:
                 result.append(call.transaction_hash)
 
     return result
-
-
-def cache_block(cache_path: Path, block: Block):
-    write_mode = "w" if cache_path.is_file() else "x"
-
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-
-    with open(cache_path, mode=write_mode) as cache_file:
-        cache_file.write(block.json())
-
-
-def _get_cache_path(block_number: int) -> Path:
-    cache_directory_path = Path(cache_directory)
-    return cache_directory_path / f"{block_number}.json"

--- a/mev_inspect/inspector.py
+++ b/mev_inspect/inspector.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import sys
 import traceback
 from asyncio import CancelledError
 from typing import Optional
@@ -14,7 +13,6 @@ from mev_inspect.classifiers.trace import TraceClassifier
 from mev_inspect.inspect_block import inspect_block
 from mev_inspect.provider import get_base_provider
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/mev_inspect/retry.py
+++ b/mev_inspect/retry.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import random
-import sys
 from typing import (
     Any,
     Callable,
@@ -39,7 +38,6 @@ aiohttp_exceptions = (
     ClientResponseError,
 )
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Currently `logging.basicConfig` is getting set from many places in the codebase

We use different base logging configs depending on who is starting the command
- For the cli, we want standard out
- For loop, we want it to log to a file
- And for listener, we want it to log to a different file

Setting in the multiple places was overwriting these distinct configurations

Now we only set once in each entry point