### PR TITLE
Fix arbitrage swap double entry bug

### DIFF
--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -88,14 +88,14 @@ def _get_all_start_end_swaps(swaps: List[Swap]) -> List[Tuple[Swap, Swap]]:
     """
     pool_addrs = [swap.contract_address for swap in swaps]
     valid_start_ends: List[Tuple[Swap, Swap]] = []
-    for potential_start_swap in swaps:
-        for potential_end_swap in swaps:
+    for index, potential_start_swap in enumerate(swaps):
+        remaining_swaps = swaps[:index] + swaps[index + 1 :]
+        for potential_end_swap in remaining_swaps:
             if (
                 potential_start_swap.token_in_address
                 == potential_end_swap.token_out_address
                 and potential_start_swap.from_address == potential_end_swap.to_address
                 and not potential_start_swap.from_address in pool_addrs
-                and potential_start_swap != potential_end_swap
             ):
                 valid_start_ends.append((potential_start_swap, potential_end_swap))
     return valid_start_ends

--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -95,6 +95,7 @@ def _get_all_start_end_swaps(swaps: List[Swap]) -> List[Tuple[Swap, Swap]]:
                 == potential_end_swap.token_out_address
                 and potential_start_swap.from_address == potential_end_swap.to_address
                 and not potential_start_swap.from_address in pool_addrs
+                and potential_start_swap != potential_end_swap
             ):
                 valid_start_ends.append((potential_start_swap, potential_end_swap))
     return valid_start_ends


### PR DESCRIPTION
## Resolution to Issue #145 
As highlighted in the issue, there was a bug in getting arbitrages where, in certain cases, a start/end pair with equal entries would be passed as a valid. This causes the arbitrage swaps list to contain a double entry, which breaks when writing to the db due to a non-unique primary key. The error occurred every couple hundred blocks. A check can be introduced to remove this from the valid start/end pairs.

## TLDR
- Introduce a check for valid arbitrage start/end pairs where the start/end swaps cannot be the same swap