### PR TITLE
Speed up the tests by sharing trace_classifier

### DIFF
--- a/mev
+++ b/mev
@@ -48,8 +48,9 @@ case "$1" in
             poetry run inspect-many-blocks $start_block_number $end_block_number
 	;;
   test)
+        shift
         echo "Running tests"
-        kubectl exec -ti deploy/mev-inspect -- poetry run pytest tests
+        kubectl exec -ti deploy/mev-inspect -- poetry run pytest tests $@
 	;;
   fetch)
       block_number=$2

--- a/poetry.lock
+++ b/poetry.lock
@@ -384,6 +384,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "gprof2dot"
+version = "2021.2.21"
+description = "Generate a dot graph from the output of several profilers."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "greenlet"
 version = "1.1.1"
 description = "Lightweight in-process concurrent programming"
@@ -769,6 +777,22 @@ toml = "*"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-profiling"
+version = "1.7.0"
+description = "Profiling plugin for py.test"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+gprof2dot = "*"
+pytest = "*"
+six = "*"
+
+[package.extras]
+tests = ["pytest-virtualenv"]
+
+[[package]]
 name = "pytest-sugar"
 version = "0.9.4"
 description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
@@ -1032,7 +1056,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "03aa2d5981665ade1b81682c1e797a06b56c5fb68d61ae69fd2f1e95bd32cfb6"
+content-hash = "0aa43e887fe106d4142d68b7a891ba94f2de28df9df0ed765d285b1e5ccee391"
 
 [metadata.files]
 aiohttp = [
@@ -1361,6 +1385,9 @@ frozenlist = [
     {file = "frozenlist-1.2.0-cp39-cp39-win32.whl", hash = "sha256:83334e84a290a158c0c4cc4d22e8c7cfe0bba5b76d37f1c2509dabd22acafe15"},
     {file = "frozenlist-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:735f386ec522e384f511614c01d2ef9cf799f051353876b4c6fb93ef67a6d1ee"},
     {file = "frozenlist-1.2.0.tar.gz", hash = "sha256:68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de"},
+]
+gprof2dot = [
+    {file = "gprof2dot-2021.2.21.tar.gz", hash = "sha256:1223189383b53dcc8ecfd45787ac48c0ed7b4dbc16ee8b88695d053eea1acabf"},
 ]
 greenlet = [
     {file = "greenlet-1.1.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:476ba9435afaead4382fbab8f1882f75e3fb2285c35c9285abb3dd30237f9142"},
@@ -1770,6 +1797,12 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
+]
+pytest-profiling = [
+    {file = "pytest-profiling-1.7.0.tar.gz", hash = "sha256:93938f147662225d2b8bd5af89587b979652426a8a6ffd7e73ec4a23e24b7f29"},
+    {file = "pytest_profiling-1.7.0-py2.7.egg", hash = "sha256:3b255f9db36cb2dd7536a8e7e294c612c0be7f7850a7d30754878e4315d56600"},
+    {file = "pytest_profiling-1.7.0-py2.py3-none-any.whl", hash = "sha256:999cc9ac94f2e528e3f5d43465da277429984a1c237ae9818f8cfd0b06acb019"},
+    {file = "pytest_profiling-1.7.0-py3.6.egg", hash = "sha256:6bce4e2edc04409d2f3158c16750fab8074f62d404cc38eeb075dff7fcbb996c"},
 ]
 pytest-sugar = [
     {file = "pytest-sugar-0.9.4.tar.gz", hash = "sha256:b1b2186b0a72aada6859bea2a5764145e3aaa2c1cfbb23c3a19b5f7b697563d3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ coverage = "^5.5"
 alembic = "^1.6.5"
 CProfileV = "^1.0.7"
 regex = "^2021.10.8"
+pytest-profiling = "^1.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,13 @@ from typing import List
 
 import pytest
 
+from mev_inspect.classifiers.trace import TraceClassifier
+
+
+@pytest.fixture(scope="session")
+def trace_classifier() -> TraceClassifier:
+    return TraceClassifier()
+
 
 @pytest.fixture(name="get_transaction_hashes")
 def fixture_get_transaction_hashes():

--- a/tests/liquidation_test.py
+++ b/tests/liquidation_test.py
@@ -8,8 +8,7 @@ from mev_inspect.transfers import ETH_TOKEN_ADDRESS
 from tests.utils import load_test_block
 
 
-def test_single_weth_liquidation():
-
+def test_single_weth_liquidation(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0xb7575eedc9d8cfe82c4a11cd1a851221f2eafb93d738301995ac7103ffe877f7"
     )
@@ -31,15 +30,13 @@ def test_single_weth_liquidation():
     ]
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_aave_liquidations(classified_traces)
 
     _assert_equal_list_of_liquidations(result, liquidations)
 
 
-def test_single_liquidation():
-
+def test_single_liquidation(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0xe6c0e3ef0436cb032e1ef292141f4fc4dcd47a75a2559602133114952190e76b"
     )
@@ -61,15 +58,13 @@ def test_single_liquidation():
     ]
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_aave_liquidations(classified_traces)
 
     _assert_equal_list_of_liquidations(result, liquidations)
 
 
-def test_single_liquidation_with_atoken_payback():
-
+def test_single_liquidation_with_atoken_payback(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0xde551a73e813f1a1e5c843ac2c6a0e40d71618f4040bb7d0cd7cf7b2b6cf4633"
     )
@@ -91,15 +86,13 @@ def test_single_liquidation_with_atoken_payback():
     ]
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_aave_liquidations(classified_traces)
 
     _assert_equal_list_of_liquidations(result, liquidations)
 
 
-def test_multiple_liquidations_in_block():
-
+def test_multiple_liquidations_in_block(trace_classifier: TraceClassifier):
     transaction1 = "0xedd062c3a728db4b114f2e83cac281d19a9f753e36afa8a35cdbdf1e1dd5d017"
     transaction2 = "0x18492f250cf4735bd67a21c6cc26b7d9c59cf2fb077356dc924f36bc68a810e5"
     transaction3 = "0x191b05b28ebaf460e38e90ac6a801681b500f169041ae83a45b32803ef2ec98c"
@@ -145,7 +138,6 @@ def test_multiple_liquidations_in_block():
     )
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_aave_liquidations(classified_traces)
     liquidations = [liquidation1, liquidation2, liquidation3]
@@ -153,8 +145,7 @@ def test_multiple_liquidations_in_block():
     _assert_equal_list_of_liquidations(result, liquidations)
 
 
-def test_liquidations_with_eth_transfer():
-
+def test_liquidations_with_eth_transfer(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0xf687fedbc4bbc25adb3ef3a35c20c38fb7d35d86d7633d5061d2e3c4f86311b7"
     )
@@ -187,7 +178,6 @@ def test_liquidations_with_eth_transfer():
     )
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_aave_liquidations(classified_traces)
     liquidations = [liquidation1, liquidation2]

--- a/tests/test_0x.py
+++ b/tests/test_0x.py
@@ -5,8 +5,7 @@ from mev_inspect.classifiers.trace import TraceClassifier
 from tests.utils import load_test_block
 
 
-def test_fillLimitOrder_swap():
-
+def test_fillLimitOrder_swap(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0xa043976d736ec8dc930c0556dffd0a86a4bfc80bf98fb7995c791fb4dc488b5d"
     )
@@ -29,15 +28,13 @@ def test_fillLimitOrder_swap():
     )
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_swaps(classified_traces)
 
     assert result.count(swap) == 1
 
 
-def test__fillLimitOrder_swap():
-
+def test__fillLimitOrder_swap(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0x9255addffa2dbeb9560c5e20e78a78c949488d2054c70b2155c39f9e28394cbf"
     )
@@ -60,15 +57,13 @@ def test__fillLimitOrder_swap():
     )
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_swaps(classified_traces)
 
     assert result.count(swap) == 1
 
 
-def test_RfqLimitOrder_swap():
-
+def test_RfqLimitOrder_swap(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0x1c948eb7c59ddbe6b916cf68f5df86eb44a7c9e728221fcd8ab750f137fd2a0f"
     )
@@ -91,15 +86,13 @@ def test_RfqLimitOrder_swap():
     )
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_swaps(classified_traces)
 
     assert result.count(swap) == 1
 
 
-def test__RfqLimitOrder_swap():
-
+def test__RfqLimitOrder_swap(trace_classifier: TraceClassifier):
     transaction_hash = (
         "0x4f66832e654f8a4d773d9769571155df3722401343247376d6bb56626db29b90"
     )
@@ -122,7 +115,6 @@ def test__RfqLimitOrder_swap():
     )
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_swaps(classified_traces)
 

--- a/tests/test_arbitrage_integration.py
+++ b/tests/test_arbitrage_integration.py
@@ -5,10 +5,8 @@ from mev_inspect.swaps import get_swaps
 from .utils import load_test_block
 
 
-def test_arbitrage_real_block():
+def test_arbitrage_real_block(trace_classifier: TraceClassifier):
     block = load_test_block(12914944)
-
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
 
     swaps = get_swaps(classified_traces)

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -8,7 +8,7 @@ comp_markets = load_comp_markets()
 cream_markets = load_cream_markets()
 
 
-def test_c_ether_liquidations():
+def test_c_ether_liquidations(trace_classifier: TraceClassifier):
     block_number = 13234998
     transaction_hash = (
         "0x78f7e67391c2bacde45e5057241f8b9e21a59330bce4332eecfff8fac279d090"
@@ -28,7 +28,6 @@ def test_c_ether_liquidations():
         )
     ]
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_compound_liquidations(classified_traces)
     assert result == liquidations
@@ -53,7 +52,6 @@ def test_c_ether_liquidations():
     ]
 
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_compound_liquidations(classified_traces)
     assert result == liquidations
@@ -77,13 +75,12 @@ def test_c_ether_liquidations():
         )
     ]
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_compound_liquidations(classified_traces)
     assert result == liquidations
 
 
-def test_c_token_liquidation():
+def test_c_token_liquidation(trace_classifier: TraceClassifier):
     block_number = 13326607
     transaction_hash = (
         "0x012215bedd00147c58e1f59807664914b2abbfc13c260190dc9cfc490be3e343"
@@ -103,13 +100,12 @@ def test_c_token_liquidation():
         )
     ]
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_compound_liquidations(classified_traces)
     assert result == liquidations
 
 
-def test_cream_token_liquidation():
+def test_cream_token_liquidation(trace_classifier: TraceClassifier):
     block_number = 12674514
     transaction_hash = (
         "0x0809bdbbddcf566e5392682a9bd9d0006a92a4dc441163c791b1136f982994b1"
@@ -129,7 +125,6 @@ def test_cream_token_liquidation():
         )
     ]
     block = load_test_block(block_number)
-    trace_classifier = TraceClassifier()
     classified_traces = trace_classifier.classify(block.traces)
     result = get_compound_liquidations(classified_traces)
     assert result == liquidations


### PR DESCRIPTION
Brings us from 52 secs => 25 secs to run all

Also adds an option `--profile` to see what's slow