### PR TITLE
Fix 0x reverted orders bug 

### DIFF
--- a/mev_inspect/classifiers/specs/zero_ex.py
+++ b/mev_inspect/classifiers/specs/zero_ex.py
@@ -231,7 +231,10 @@ def _get_taker_token_in_amount(
     child_transfers: List[Transfer],
 ) -> int:
 
-    if len(child_transfers) != 2 and trace.error == None:
+    if trace.error is not None:
+        return 0
+
+    if len(child_transfers) != 2:
         raise ValueError(
             f"A settled order should consist of 2 child transfers, not {len(child_transfers)}."
         )

--- a/mev_inspect/classifiers/specs/zero_ex.py
+++ b/mev_inspect/classifiers/specs/zero_ex.py
@@ -234,7 +234,7 @@ def _get_taker_token_in_amount(
     if trace.error is not None:
         return 0
 
-    if len(child_transfers) != 2:
+    if len(child_transfers) < 2:
         raise ValueError(
             f"A settled order should consist of 2 child transfers, not {len(child_transfers)}."
         )

--- a/mev_inspect/classifiers/specs/zero_ex.py
+++ b/mev_inspect/classifiers/specs/zero_ex.py
@@ -248,7 +248,7 @@ def _get_taker_token_in_amount(
             if transfer.to_address == taker_address:
                 return transfer.amount
 
-    raise ValueError("Unable to find transfers matching 0x order.")
+    raise RuntimeError("Unable to find transfers matching 0x order.")
 
 
 def _get_0x_token_in_data(

--- a/mev_inspect/classifiers/specs/zero_ex.py
+++ b/mev_inspect/classifiers/specs/zero_ex.py
@@ -225,10 +225,13 @@ ZEROX_CLASSIFIER_SPECS = ZEROX_CONTRACT_SPECS + ZEROX_GENERIC_SPECS
 
 
 def _get_taker_token_in_amount(
-    taker_address: str, token_in_address: str, child_transfers: List[Transfer]
+    trace: DecodedCallTrace,
+    taker_address: str,
+    token_in_address: str,
+    child_transfers: List[Transfer],
 ) -> int:
 
-    if len(child_transfers) != 2:
+    if len(child_transfers) != 2 and trace.error == None:
         raise ValueError(
             f"A settled order should consist of 2 child transfers, not {len(child_transfers)}."
         )
@@ -263,7 +266,7 @@ def _get_0x_token_in_data(
         )
 
     token_in_amount = _get_taker_token_in_amount(
-        taker_address, token_in_address, child_transfers
+        trace, taker_address, token_in_address, child_transfers
     )
 
     return token_in_address, token_in_amount

--- a/mev_inspect/classifiers/specs/zero_ex.py
+++ b/mev_inspect/classifiers/specs/zero_ex.py
@@ -247,7 +247,8 @@ def _get_taker_token_in_amount(
         for transfer in child_transfers:
             if transfer.to_address == taker_address:
                 return transfer.amount
-    return 0
+
+    raise ValueError("Unable to find transfers matching 0x order.")
 
 
 def _get_0x_token_in_data(


### PR DESCRIPTION
## Overview
Some 0x orders are reverted which fails in the swap classifier during the search for the transfers.

>> https://etherscan.io/tx/0xdc6259a4bc95044e23290f6b6e894e0ae7aa8474a3e38218b272e47a50ad297e

 Introduces a check for the status of the order and only throws the error in the case the transaction is not reverted.
