### PR TITLE
Add block timestamp to liquidations table

### DIFF
--- a/alembic/versions/f19270a53410_add_block_timestamp_to_liquidations.py
+++ b/alembic/versions/f19270a53410_add_block_timestamp_to_liquidations.py
@@ -1,0 +1,28 @@
+"""Add block timestamp to liquidations
+
+Revision ID: f19270a53410
+Revises: 52d75a7e0533
+Create Date: 2021-12-14 02:40:46.802125
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f19270a53410"
+down_revision = "52d75a7e0533"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "liquidations", sa.Column("block_timestamp", sa.TIMESTAMP, nullable=True)
+    )
+    pass
+
+
+def downgrade():
+    sa.drop_column("block_timestamp", "liquidations")
+    pass


### PR DESCRIPTION
## Overview
Adds block timestamp field to liquidations to permit matching with the prices table. This will allow profit calculation at the query level