### PR TITLE
Fix listener first startup

### DIFF
--- a/listener
+++ b/listener
@@ -23,6 +23,7 @@ case "$1" in
   stop)
         echo -n "Stopping daemon: "$NAME
 	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+    rm $PIDFILE
         echo "."
 	;;
   tail)
@@ -31,6 +32,7 @@ case "$1" in
   restart)
         echo -n "Restarting daemon: "$NAME
 	start-stop-daemon --stop --quiet --oknodo --retry 30 --pidfile $PIDFILE
+    rm $PIDFILE
 	start-stop-daemon \
         --background \
         --chdir /app \

--- a/listener.py
+++ b/listener.py
@@ -65,14 +65,10 @@ async def inspect_next_block(
 
     if last_written_block is None:
         # maintain lag if no blocks written yet
-        last_written_block = latest_block_number - 1
+        last_written_block = latest_block_number - BLOCK_NUMBER_LAG - 1
 
     if last_written_block < (latest_block_number - BLOCK_NUMBER_LAG):
-        block_number = (
-            latest_block_number
-            if last_written_block is None
-            else last_written_block + 1
-        )
+        block_number = last_written_block + 1
 
         logger.info(f"Writing block: {block_number}")
 


### PR DESCRIPTION
On the first run, the listener currently gets stuck as block to inspect = None because it:
- Fetches the last inspected block (none)
- Sets it to one behind the latest
- Fails the check that the last inspected lags 5 behind latest
- Repeats

This changes to set it behind the block lag from the start

Also fixes an issue with start / stop on the listener where the pidfile gets left behind preventing the next start