### PR TITLE
Append a random number to postgres client

### DIFF
--- a/mev
+++ b/mev
@@ -13,7 +13,7 @@ function db(){
     username=$(get_kube_db_secret "username")
     password=$(get_kube_db_secret "password")
 
-    kubectl run -i --rm --tty postgres-client \
+    kubectl run -i --rm --tty postgres-client-$RANDOM \
         --env="PGPASSWORD=$password"  \
         --image=jbergknoff/postgresql-client \
         -- $DB_NAME --host=$host --user=$username


### PR DESCRIPTION
For shared kubernetes clusters, if multiple people connect to postgres through the client there's a name conflict

This appends a random number to the client name so multiple can be spun up