### PR TITLE
Only use each swap in a single arbitrage

### DIFF
--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -93,7 +93,6 @@ def _get_shortest_route(
     end_swaps: List[Swap],
     all_swaps: List[Swap],
 ) -> Optional[List[Swap]]:
-    # TODO - add max length
     for end_swap in end_swaps:
         if start_swap.token_out_address == end_swap.token_in_address:
             return [start_swap, end_swap]

--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -132,7 +132,7 @@ def _get_shortest_route(
 
 def _get_all_start_end_swaps(swaps: List[Swap]) -> List[Tuple[Swap, List[Swap]]]:
     """
-    Gets the set of all possible opening and closing swap pairs in an arbitrage via
+    Gets the set of all possible openings and corresponding closing swaps for an arbitrage via
     - swap[start].token_in == swap[end].token_out
     - swap[start].from_address == swap[end].to_address
     - not swap[start].from_address in all_pool_addresses

--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -51,7 +51,7 @@ def _get_arbitrages_from_swaps(swaps: List[Swap]) -> List[Arbitrage]:
         if start in used_swaps:
             continue
 
-        longest_route = None
+        shortest_route = None
 
         for end in ends:
             if end in used_swaps:
@@ -70,12 +70,12 @@ def _get_arbitrages_from_swaps(swaps: List[Swap]) -> List[Arbitrage]:
             )
 
             for route in routes:
-                if longest_route is None or len(route) > len(longest_route):
-                    longest_route = route
+                if shortest_route is None or len(route) < len(shortest_route):
+                    shortest_route = route
 
-        if longest_route is not None:
-            start_amount = longest_route[0].token_in_amount
-            end_amount = longest_route[-1].token_out_amount
+        if shortest_route is not None:
+            start_amount = shortest_route[0].token_in_amount
+            end_amount = shortest_route[-1].token_out_amount
             profit_amount = end_amount - start_amount
             error = None
             for swap in route:
@@ -83,11 +83,11 @@ def _get_arbitrages_from_swaps(swaps: List[Swap]) -> List[Arbitrage]:
                     error = swap.error
 
             arb = Arbitrage(
-                swaps=longest_route,
-                block_number=longest_route[0].block_number,
-                transaction_hash=longest_route[0].transaction_hash,
-                account_address=longest_route[0].from_address,
-                profit_token_address=longest_route[0].token_in_address,
+                swaps=shortest_route,
+                block_number=shortest_route[0].block_number,
+                transaction_hash=shortest_route[0].transaction_hash,
+                account_address=shortest_route[0].from_address,
+                profit_token_address=shortest_route[0].token_in_address,
                 start_amount=start_amount,
                 end_amount=end_amount,
                 profit_amount=profit_amount,
@@ -95,7 +95,7 @@ def _get_arbitrages_from_swaps(swaps: List[Swap]) -> List[Arbitrage]:
             )
 
             all_arbitrages.append(arb)
-            used_swaps.extend(longest_route)
+            used_swaps.extend(shortest_route)
 
     if len(all_arbitrages) == 1:
         return all_arbitrages

--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -104,7 +104,7 @@ def _get_shortest_route(
     if len(other_swaps) == 0:
         return None
 
-    shortest_route_rest = None
+    shortest_remaining_route = None
 
     for next_swap in other_swaps:
         if start_swap.token_out_address == next_swap.token_in_address and (
@@ -119,15 +119,15 @@ def _get_shortest_route(
             )
 
             if shortest_from_next is not None and (
-                shortest_route_rest is None
-                or len(shortest_from_next) < len(shortest_route_rest)
+                shortest_remaining_route is None
+                or len(shortest_from_next) < len(shortest_remaining_route)
             ):
-                shortest_route_rest = shortest_from_next
+                shortest_remaining_route = shortest_from_next
 
-    if shortest_route_rest is None:
+    if shortest_remaining_route is None:
         return None
     else:
-        return [start_swap] + shortest_route_rest
+        return [start_swap] + shortest_remaining_route
 
 
 def _get_all_start_end_swaps(swaps: List[Swap]) -> List[Tuple[Swap, List[Swap]]]:

--- a/tests/test_arbitrage_integration.py
+++ b/tests/test_arbitrage_integration.py
@@ -67,7 +67,7 @@ def test_reverting_arbitrage(trace_classifier: TraceClassifier):
     assert len(swaps) == 38
 
     arbitrages = get_arbitrages(list(swaps))
-    assert len(arbitrages) == 21
+    assert len(arbitrages) == 4
 
     arbitrage_1 = [
         arb

--- a/tests/test_arbitrages.py
+++ b/tests/test_arbitrages.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from mev_inspect.arbitrages import _get_shortest_route, get_arbitrages
 from mev_inspect.classifiers.specs.uniswap import (
@@ -175,42 +175,37 @@ def test_get_shortest_route():
     # A -> B, B -> A
     start_swap = create_generic_swap("0xa", "0xb")
     end_swap = create_generic_swap("0xb", "0xa")
-    route = _get_shortest_route(start_swap, [end_swap], [])
-    assert route is not None
-    assert len(route) == 2
+    shortest_route = _get_shortest_route(start_swap, [end_swap], [])
+    assert shortest_route is not None
+    assert len(shortest_route) == 2
 
     # A->B, B->C, C->A
     start_swap = create_generic_swap("0xa", "0xb")
     other_swaps = [create_generic_swap("0xb", "0xc")]
     end_swap = create_generic_swap("0xc", "0xa")
-    route = _get_shortest_route(start_swap, [end_swap], other_swaps)
-    assert route is not None
-    assert len(route) == 3
+    shortest_route = _get_shortest_route(start_swap, [end_swap], other_swaps)
+    assert shortest_route is not None
+    assert len(shortest_route) == 3
 
     # A->B, B->C, C->A + A->D
     other_swaps.append(create_generic_swap("0xa", "0xd"))
-    route = _get_shortest_route(start_swap, [end_swap], other_swaps)
-    assert route is not None
-    assert len(route) == 3
+    shortest_route = _get_shortest_route(start_swap, [end_swap], other_swaps)
+    assert shortest_route is not None
+    assert len(shortest_route) == 3
 
     # A->B, B->C, C->A + A->D B->E
     other_swaps.append(create_generic_swap("0xb", "0xe"))
-    route = _get_shortest_route(start_swap, [end_swap], other_swaps)
-    assert route is not None
-    assert len(route) == 3
+    shortest_route = _get_shortest_route(start_swap, [end_swap], other_swaps)
+    assert shortest_route is not None
+    assert len(shortest_route) == 3
 
     # A->B, B->A, B->C, C->A
     other_swaps = [create_generic_swap("0xb", "0xa"), create_generic_swap("0xb", "0xc")]
-    route = _get_shortest_route(start_swap, [end_swap], other_swaps)
-    expected_smallest_route = [["0xa", "0xb"], ["0xb", "0xc"], ["0xc", "0xa"]]
+    actual_shortest_route = _get_shortest_route(start_swap, [end_swap], other_swaps)
+    expected_shortest_route = [("0xa", "0xb"), ("0xb", "0xc"), ("0xc", "0xa")]
 
-    assert route is not None
-    assert len(route) == len(expected_smallest_route)
-    for i, [expected_token_in, expected_token_out] in enumerate(
-        expected_smallest_route
-    ):
-        assert expected_token_in == route[i].token_in_address
-        assert expected_token_out == route[i].token_out_address
+    assert actual_shortest_route is not None
+    _assert_route_tokens_equal(actual_shortest_route, expected_shortest_route)
 
     # A->B, B->C, C->D, D->A, B->D
     end_swap = create_generic_swap("0xd", "0xa")
@@ -219,12 +214,21 @@ def test_get_shortest_route():
         create_generic_swap("0xc", "0xd"),
         create_generic_swap("0xb", "0xd"),
     ]
-    expected_smallest_route = [["0xa", "0xb"], ["0xb", "0xd"], ["0xd", "0xa"]]
-    route = _get_shortest_route(start_swap, [end_swap], other_swaps)
-    assert len(route) == 3
+    expected_shortest_route = [("0xa", "0xb"), ("0xb", "0xd"), ("0xd", "0xa")]
+    actual_shortest_route = _get_shortest_route(start_swap, [end_swap], other_swaps)
+
+    assert actual_shortest_route is not None
+    _assert_route_tokens_equal(actual_shortest_route, expected_shortest_route)
+
+
+def _assert_route_tokens_equal(
+    route: List[Swap],
+    expected_token_in_out_pairs: List[Tuple[str, str]],
+) -> None:
+    assert len(route) == len(expected_token_in_out_pairs)
 
     for i, [expected_token_in, expected_token_out] in enumerate(
-        expected_smallest_route
+        expected_token_in_out_pairs
     ):
         assert expected_token_in == route[i].token_in_address
         assert expected_token_out == route[i].token_out_address


### PR DESCRIPTION
Fixes https://github.com/flashbots/mev-inspect-py/issues/176

## Current
We allow a swap to participate in multiple arbs

This causes bad data and also leads to some nasty duplicate issues (like getting stuck creating 13k arbs https://github.com/flashbots/mev-inspect-py/issues/176)

## This PR
Picks the shortest length route as the best route for a swap to participate in

If I do two arbs like:
A =pool 1=> B =pool 2=> A
and
A =pool 3=> C =pool 4=> A

picking the shortest would create 2 arbs instead of one long one involving all, which would mean the same total profit but with a more specific description of what's happening

## Testing

Verified all blocks in https://github.com/flashbots/mev-inspect-py/issues/176 work now

All tests pass

Looking at block `11421847` looking at profit you can see the same tokens being wrapped around multiple times
![image](https://user-images.githubusercontent.com/5885679/147116882-672f519b-b6c1-4b60-bb38-5631e061d584.png)
