### PR TITLE
Inspect block should write all

### DIFF
--- a/mev_inspect/crud/blocks.py
+++ b/mev_inspect/crud/blocks.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import List
 
 from mev_inspect.schemas.blocks import Block
 
@@ -23,15 +24,20 @@ def delete_blocks(
     db_session.commit()
 
 
-def write_block(
+def write_blocks(
     db_session,
-    block: Block,
+    blocks: List[Block],
 ) -> None:
-    db_session.execute(
-        "INSERT INTO blocks (block_number, block_timestamp) VALUES (:block_number, :block_timestamp)",
-        params={
+    block_params = [
+        {
             "block_number": block.block_number,
             "block_timestamp": datetime.fromtimestamp(block.block_timestamp),
-        },
+        }
+        for block in blocks
+    ]
+
+    db_session.execute(
+        "INSERT INTO blocks (block_number, block_timestamp) VALUES (:block_number, :block_timestamp)",
+        params=block_params,
     )
     db_session.commit()

--- a/mev_inspect/inspect_block.py
+++ b/mev_inspect/inspect_block.py
@@ -8,7 +8,7 @@ from mev_inspect.arbitrages import get_arbitrages
 from mev_inspect.block import create_from_block_number
 from mev_inspect.classifiers.trace import TraceClassifier
 from mev_inspect.crud.arbitrages import delete_arbitrages_for_blocks, write_arbitrages
-from mev_inspect.crud.blocks import delete_blocks, write_block
+from mev_inspect.crud.blocks import delete_blocks, write_blocks
 from mev_inspect.crud.liquidations import (
     delete_liquidations_for_blocks,
     write_liquidations,
@@ -89,7 +89,7 @@ async def inspect_many_blocks(
     all_transfers: List[Transfer] = []
     all_swaps: List[Swap] = []
     all_arbitrages: List[Arbitrage] = []
-    all_liqudations: List[Liquidation] = []
+    all_liquidations: List[Liquidation] = []
     all_sandwiches: List[Sandwich] = []
 
     all_punk_bids: List[PunkBid] = []
@@ -153,7 +153,7 @@ async def inspect_many_blocks(
         all_transfers.extend(transfers)
         all_swaps.extend(swaps)
         all_arbitrages.extend(arbitrages)
-        all_liqudations.extend(liquidations)
+        all_liquidations.extend(liquidations)
         all_sandwiches.extend(sandwiches)
 
         all_punk_bids.extend(punk_bids)
@@ -163,53 +163,53 @@ async def inspect_many_blocks(
         all_miner_payments.extend(miner_payments)
 
     delete_blocks(inspect_db_session, after_block_number, before_block_number)
-    write_block(inspect_db_session, block)
+    write_blocks(inspect_db_session, all_blocks)
 
     if should_write_classified_traces:
         delete_classified_traces_for_blocks(
             inspect_db_session, after_block_number, before_block_number
         )
-        write_classified_traces(inspect_db_session, classified_traces)
+        write_classified_traces(inspect_db_session, all_classified_traces)
 
     delete_transfers_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_transfers(inspect_db_session, transfers)
+    write_transfers(inspect_db_session, all_transfers)
 
     delete_swaps_for_blocks(inspect_db_session, after_block_number, before_block_number)
-    write_swaps(inspect_db_session, swaps)
+    write_swaps(inspect_db_session, all_swaps)
 
     delete_arbitrages_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_arbitrages(inspect_db_session, arbitrages)
+    write_arbitrages(inspect_db_session, all_arbitrages)
 
     delete_liquidations_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_liquidations(inspect_db_session, liquidations)
+    write_liquidations(inspect_db_session, all_liquidations)
 
     delete_sandwiches_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_sandwiches(inspect_db_session, sandwiches)
+    write_sandwiches(inspect_db_session, all_sandwiches)
 
     delete_punk_bids_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_punk_bids(inspect_db_session, punk_bids)
+    write_punk_bids(inspect_db_session, all_punk_bids)
 
     delete_punk_bid_acceptances_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_punk_bid_acceptances(inspect_db_session, punk_bid_acceptances)
+    write_punk_bid_acceptances(inspect_db_session, all_punk_bid_acceptances)
 
     delete_punk_snipes_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_punk_snipes(inspect_db_session, punk_snipes)
+    write_punk_snipes(inspect_db_session, all_punk_snipes)
 
     delete_miner_payments_for_blocks(
         inspect_db_session, after_block_number, before_block_number
     )
-    write_miner_payments(inspect_db_session, miner_payments)
+    write_miner_payments(inspect_db_session, all_miner_payments)


### PR DESCRIPTION
Fixes a bug in bulk writing that only writes every 10th block

Currently we write ex: "swaps" but should be writing all swaps found across blocks "all_swaps"

This fixes that