### PR TITLE
Use middleware for all RPC calls

### DIFF
--- a/mev_inspect/block.py
+++ b/mev_inspect/block.py
@@ -24,7 +24,6 @@ async def get_latest_block_number(base_provider) -> int:
 
 
 async def create_from_block_number(
-    base_provider,
     w3: Web3,
     block_number: int,
     trace_db_session: Optional[orm.Session],
@@ -35,34 +34,22 @@ async def create_from_block_number(
         block = _find_block(trace_db_session, block_number)
 
     if block is None:
-        block = await _fetch_block(w3, base_provider, block_number)
+        block = await _fetch_block(w3, block_number)
         return block
     else:
         return block
 
 
-async def _fetch_block(w3, base_provider, block_number: int, retries: int = 0) -> Block:
+async def _fetch_block(w3, block_number: int) -> Block:
     block_json, receipts_json, traces_json, base_fee_per_gas = await asyncio.gather(
         w3.eth.get_block(block_number),
-        base_provider.make_request("eth_getBlockReceipts", [block_number]),
-        base_provider.make_request("trace_block", [block_number]),
+        w3.eth.get_block_receipts(block_number),
+        w3.eth.trace_block(block_number),
         fetch_base_fee_per_gas(w3, block_number),
     )
 
-    try:
-        receipts: List[Receipt] = [
-            Receipt(**receipt) for receipt in receipts_json["result"]
-        ]
-        traces = [Trace(**trace_json) for trace_json in traces_json["result"]]
-    except KeyError as e:
-        logger.warning(
-            f"Failed to create objects from block: {block_number}: {e}, retrying: {retries + 1} / 3"
-        )
-        if retries < 3:
-            await asyncio.sleep(5)
-            return await _fetch_block(w3, base_provider, block_number, retries)
-        else:
-            raise
+    receipts: List[Receipt] = [Receipt(**receipt) for receipt in receipts_json]
+    traces = [Trace(**trace_json) for trace_json in traces_json]
 
     return Block(
         block_number=block_number,

--- a/mev_inspect/inspect_block.py
+++ b/mev_inspect/inspect_block.py
@@ -55,7 +55,6 @@ logger = logging.getLogger(__name__)
 
 async def inspect_block(
     inspect_db_session: orm.Session,
-    base_provider,
     w3: Web3,
     trace_classifier: TraceClassifier,
     block_number: int,
@@ -64,7 +63,6 @@ async def inspect_block(
 ):
     await inspect_many_blocks(
         inspect_db_session,
-        base_provider,
         w3,
         trace_classifier,
         block_number,
@@ -76,7 +74,6 @@ async def inspect_block(
 
 async def inspect_many_blocks(
     inspect_db_session: orm.Session,
-    base_provider,
     w3: Web3,
     trace_classifier: TraceClassifier,
     after_block_number: int,
@@ -100,7 +97,6 @@ async def inspect_many_blocks(
 
     for block_number in range(after_block_number, before_block_number):
         block = await create_from_block_number(
-            base_provider,
             w3,
             block_number,
             trace_db_session,

--- a/mev_inspect/methods.py
+++ b/mev_inspect/methods.py
@@ -1,0 +1,16 @@
+from typing import Callable, List
+
+from web3._utils.rpc_abi import RPC
+from web3.method import Method, default_root_munger
+from web3.types import BlockIdentifier, ParityBlockTrace, RPCEndpoint
+
+trace_block: Method[Callable[[BlockIdentifier], List[ParityBlockTrace]]] = Method(
+    RPC.trace_block,
+    mungers=[default_root_munger],
+)
+
+
+get_block_receipts: Method[Callable[[BlockIdentifier], List[dict]]] = Method(
+    RPCEndpoint("eth_getBlockReceipts"),
+    mungers=[default_root_munger],
+)

--- a/mev_inspect/retry.py
+++ b/mev_inspect/retry.py
@@ -1,7 +1,7 @@
-import asyncio
 import logging
 import random
 from asyncio.exceptions import TimeoutError
+from time import sleep
 from typing import Any, Callable, Collection, Coroutine, Type
 
 from aiohttp.client_exceptions import (
@@ -49,13 +49,14 @@ async def exception_retry_with_backoff_middleware(
                     logger.error(
                         f"Request for method {method}, block: {int(params[0], 16)}, retrying: {i}/{retries}"
                     )
-                    if i < retries - 1:
+                    if i < (retries - 1):
                         backoff_time = backoff_time_seconds * (
                             random.uniform(5, 10) ** i
                         )
-                        await asyncio.sleep(backoff_time)
+                        # use blocking sleep to prevent new tries on
+                        # concurrent requests during sleep
+                        sleep(backoff_time)
                         continue
-
                     else:
                         raise
             return None

--- a/mev_inspect/retry.py
+++ b/mev_inspect/retry.py
@@ -1,7 +1,7 @@
+import asyncio
 import logging
 import random
 from asyncio.exceptions import TimeoutError
-from time import sleep
 from typing import Any, Callable, Collection, Coroutine, Type
 
 from aiohttp.client_exceptions import (
@@ -67,9 +67,7 @@ async def exception_retry_with_backoff_middleware(
                         backoff_time = backoff_time_seconds * (
                             random.uniform(5, 10) ** i
                         )
-                        # use blocking sleep to prevent new tries on
-                        # concurrent requests during sleep
-                        sleep(backoff_time)
+                        await asyncio.sleep(backoff_time)
                         continue
                     else:
                         raise

--- a/mev_inspect/retry.py
+++ b/mev_inspect/retry.py
@@ -5,6 +5,7 @@ from time import sleep
 from typing import Any, Callable, Collection, Coroutine, Type
 
 from aiohttp.client_exceptions import (
+    ClientConnectorError,
     ClientOSError,
     ClientResponseError,
     ServerDisconnectedError,
@@ -12,18 +13,31 @@ from aiohttp.client_exceptions import (
 )
 from requests.exceptions import ConnectionError, HTTPError, Timeout, TooManyRedirects
 from web3 import Web3
-from web3.middleware.exception_retry_request import check_if_retry_on_failure
+from web3.middleware.exception_retry_request import whitelist
 from web3.types import RPCEndpoint, RPCResponse
 
 request_exceptions = (ConnectionError, HTTPError, Timeout, TooManyRedirects)
 aiohttp_exceptions = (
     ClientOSError,
+    ClientResponseError,
+    ClientConnectorError,
     ServerDisconnectedError,
     ServerTimeoutError,
-    ClientResponseError,
 )
 
+whitelist_additions = ["eth_getBlockReceipts", "trace_block", "eth_feeHistory"]
+
 logger = logging.getLogger(__name__)
+
+
+def check_if_retry_on_failure(method: RPCEndpoint) -> bool:
+    root = method.split("_")[0]
+    if root in (whitelist + whitelist_additions):
+        return True
+    elif method in (whitelist + whitelist_additions):
+        return True
+    else:
+        return False
 
 
 async def exception_retry_with_backoff_middleware(
@@ -47,7 +61,7 @@ async def exception_retry_with_backoff_middleware(
                 # https://github.com/python/mypy/issues/5349
                 except errors:  # type: ignore
                     logger.error(
-                        f"Request for method {method}, block: {int(params[0], 16)}, retrying: {i}/{retries}"
+                        f"Request for method {method}, params: {params}, retrying: {i}/{retries}"
                     )
                     if i < (retries - 1):
                         backoff_time = backoff_time_seconds * (
@@ -72,5 +86,9 @@ async def http_retry_with_backoff_request_middleware(
     return await exception_retry_with_backoff_middleware(
         make_request,
         web3,
-        (request_exceptions + aiohttp_exceptions + (TimeoutError,)),
+        (
+            request_exceptions
+            + aiohttp_exceptions
+            + (TimeoutError, ConnectionRefusedError)
+        ),
     )


### PR DESCRIPTION
## Right now

We call eth_getBlockReceipts and trace_block directly from the base_provider
```
base_provider.make_request("eth_getBlockReceipts", [block_number]),
base_provider.make_request("trace_block", [block_number]),
```

Doing that bypasses the middleware in w3, most importantly the retry middleware

That means if either of these methods fail, they won't be retried

## This PR

Adds support for both of these methods on AsyncEth
Adds them to a list of retry-able methods
Calls them using w3

This has the bonus benefit of removing the need for base provider to be passed around