### PR TITLE
Fix typo in gathering blocks

### DIFF
--- a/mev_inspect/inspector.py
+++ b/mev_inspect/inspector.py
@@ -76,7 +76,7 @@ class MEVInspector:
                     )
                 )
             )
-        logger.info(f"Gathered {len(tasks)} blocks to inspect")
+        logger.info(f"Gathered {before_block-after_block} blocks to inspect")
         try:
             await asyncio.gather(*tasks)
         except CancelledError:


### PR DESCRIPTION
Currently uses len(tasks) which is wrong since we bundle multiple inspects into a task now