### PR TITLE
Be more lenient on liveness timeouts for deployments

### DIFF
--- a/k8s/mev-inspect-workers/templates/deployment.yaml
+++ b/k8s/mev-inspect-workers/templates/deployment.yaml
@@ -37,7 +37,8 @@ spec:
               - ls
               - /
             initialDelaySeconds: 20
-            periodSeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/k8s/mev-inspect/templates/deployment.yaml
+++ b/k8s/mev-inspect/templates/deployment.yaml
@@ -37,7 +37,8 @@ spec:
               - ls
               - /
             initialDelaySeconds: 20
-            periodSeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
Right now we do a basic basic liveness check on inspect deploys that we can call `ls /` on the pod

This is currently failing for some pods while they're working - default timeout is 1 second

This PR gives a little more leniency on the timeout and checks less frequently