### PR TITLE
Cut out early from arbitrages if we've already found a shorter path

### DIFF
--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -92,10 +92,20 @@ def _get_shortest_route(
     start_swap: Swap,
     end_swaps: List[Swap],
     all_swaps: List[Swap],
+    shortest_route_length: Optional[int] = None,
 ) -> Optional[List[Swap]]:
+    if len(end_swaps) == 0:
+        return None
+
+    if shortest_route_length is not None and shortest_route_length <= 2:
+        return None
+
     for end_swap in end_swaps:
         if start_swap.token_out_address == end_swap.token_in_address:
             return [start_swap, end_swap]
+
+    if shortest_route_length is not None and shortest_route_length == 3:
+        return None
 
     other_swaps = [
         swap for swap in all_swaps if (swap is not start_swap and swap not in end_swaps)
@@ -105,6 +115,9 @@ def _get_shortest_route(
         return None
 
     shortest_remaining_route = None
+    shortest_remaining_route_length = (
+        None if shortest_route_length is None else shortest_route_length - 1
+    )
 
     for next_swap in other_swaps:
         if start_swap.token_out_address == next_swap.token_in_address and (
@@ -116,6 +129,7 @@ def _get_shortest_route(
                 next_swap,
                 end_swaps,
                 other_swaps,
+                shortest_route_length=shortest_remaining_route_length,
             )
 
             if shortest_from_next is not None and (
@@ -123,6 +137,7 @@ def _get_shortest_route(
                 or len(shortest_from_next) < len(shortest_remaining_route)
             ):
                 shortest_remaining_route = shortest_from_next
+                shortest_remaining_route_length = len(shortest_from_next)
 
     if shortest_remaining_route is None:
         return None


### PR DESCRIPTION
If multiple swaps can form a circuit (arbitrage) in multiple ways, we create an arbitrage from the shortest circuit.

If multiple paths are equally short, we pick the first one.

Currently, as we're looking for shortest routes, if we find a route with length ex: 4, we'll still look for "shorter" candidate routes with depth 4, 5, 6 etc even though they'll be rejected once they're ultimately returned.

This PR adds a "shortest_route_length" parameter to communicate downward the current shortest length so we can cut out early if there are no ways to form shorter routes