### PR TITLE
Set the password in Redis statically locally

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -11,6 +11,7 @@ helm_remote("postgresql",
 helm_remote("redis",
             repo_name="bitnami",
             repo_url="https://charts.bitnami.com/bitnami",
+            set=["global.redis.password=password"],
 )
 
 k8s_yaml(configmap_from_dict("mev-inspect-rpc", inputs = {


### PR DESCRIPTION
When using Tilt, Redis restarts a decent amount

Each time the chart restarts it generates a new password

Sometimes the worker and main inspect processes don't then restart causing issues

This sets the password statically so we're more tolerant to these restarts locally