### PR TITLE
Support aave self-liquidations

### DIFF
--- a/mev_inspect/aave_liquidations.py
+++ b/mev_inspect/aave_liquidations.py
@@ -14,7 +14,7 @@ from mev_inspect.transfers import get_transfer
 
 def get_aave_liquidations(
     traces: List[ClassifiedTrace],
-) -> Optional[List[Liquidation]]:
+) -> List[Liquidation]:
 
     """Inspect list of classified traces and identify liquidation"""
     liquidations: List[Liquidation] = []

--- a/mev_inspect/aave_liquidations.py
+++ b/mev_inspect/aave_liquidations.py
@@ -103,5 +103,5 @@ def _get_debt_data(
 
     return (
         liquidation_trace.inputs["_reserve"],
-        liquidation_trace.inputs["_purchaseAmount"],
+        0,
     )


### PR DESCRIPTION
Handles two distinct edge cases:
1. AaveCore contract calls a liquidation which is internally settled and does not result in any transfers:
- There will be debt purchase data from the function inputs but received token amount is 0 since nothing is received

2. Trace contains Reverted/Out of Gas error
- Either debt or received amounts will be 0

This allows the inspector to fall back to the function inputs before throwing 