### PR TITLE
Constrain sandwiches to require similar swap amounts

### DIFF
--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 
 from mev_inspect.schemas.arbitrages import Arbitrage
 from mev_inspect.schemas.swaps import Swap
+from mev_inspect.utils import equal_within_percent
 
 MAX_TOKEN_AMOUNT_PERCENT_DIFFERENCE = 0.01
 
@@ -175,16 +176,16 @@ def _get_all_start_end_swaps(swaps: List[Swap]) -> List[Tuple[Swap, List[Swap]]]
 
 
 def _swap_outs_match_swap_ins(swap_out, swap_in) -> bool:
-    if swap_out.token_out_address == swap_in.token_in_address and (
-        swap_out.contract_address == swap_in.from_address
-        or swap_out.to_address == swap_in.contract_address
-        or swap_out.to_address == swap_in.from_address
-    ):
-        amount_percent_difference = abs(
-            (float(swap_out.token_out_amount) / swap_in.token_in_amount) - 1.0
+    return (
+        swap_out.token_out_address == swap_in.token_in_address
+        and (
+            swap_out.contract_address == swap_in.from_address
+            or swap_out.to_address == swap_in.contract_address
+            or swap_out.to_address == swap_in.from_address
         )
-
-        if amount_percent_difference < MAX_TOKEN_AMOUNT_PERCENT_DIFFERENCE:
-            return True
-
-    return False
+        and equal_within_percent(
+            swap_out.token_out_amount,
+            swap_in.token_in_amount,
+            MAX_TOKEN_AMOUNT_PERCENT_DIFFERENCE,
+        )
+    )

--- a/mev_inspect/sandwiches.py
+++ b/mev_inspect/sandwiches.py
@@ -2,6 +2,9 @@ from typing import List, Optional
 
 from mev_inspect.schemas.sandwiches import Sandwich
 from mev_inspect.schemas.swaps import Swap
+from mev_inspect.utils import equal_within_percent
+
+SANDWICH_IN_OUT_MAX_PERCENT_DIFFERENCE = 0.01
 
 
 def get_sandwiches(swaps: List[Swap]) -> List[Sandwich]:
@@ -45,10 +48,12 @@ def _get_sandwich_starting_with_swap(
             elif (
                 other_swap.token_out_address == front_swap.token_in_address
                 and other_swap.token_in_address == front_swap.token_out_address
-                and (
-                    other_swap.to_address == sandwicher_address
-                    or other_swap.from_address == sandwicher_address
+                and equal_within_percent(
+                    other_swap.token_in_amount,
+                    front_swap.token_out_amount,
+                    SANDWICH_IN_OUT_MAX_PERCENT_DIFFERENCE,
                 )
+                and other_swap.from_address == sandwicher_address
             ):
                 if len(sandwiched_swaps) > 0:
                     return Sandwich(

--- a/mev_inspect/utils.py
+++ b/mev_inspect/utils.py
@@ -3,3 +3,12 @@ from hexbytes._utils import hexstr_to_bytes
 
 def hex_to_int(value: str) -> int:
     return int.from_bytes(hexstr_to_bytes(value), byteorder="big")
+
+
+def equal_within_percent(
+    first_value: int, second_value: int, threshold_percent: float
+) -> bool:
+    difference = abs(
+        (first_value - second_value) / (0.5 * (first_value + second_value))
+    )
+    return difference < threshold_percent


### PR DESCRIPTION
Right now we allow sandwiches were the opening swap and the closing swap can be in wildly different amounts

This picks up on a lot of "accidental" sandwiches, most notably from routers

For analysis, better to only include sandwiches where it's intentional