### PR TITLE
Enforce security in k8 files

### DIFF
--- a/k8s/mev-inspect-workers/values.yaml
+++ b/k8s/mev-inspect-workers/values.yaml
@@ -17,13 +17,14 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/k8s/mev-inspect/values.yaml
+++ b/k8s/mev-inspect/values.yaml
@@ -17,13 +17,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - all
+  #readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Enforced the security options in **k8** files, for the **mev-inspect** and **mev-workers**.
I used the [snyk](https://snyk.io/) **cli** for linting and improving all the issues with medium severity.

Tested with snyk cli 1.651.0

Tom