### PR TITLE
Added block-list command to enqueue a list of blocks from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,18 @@ For messages permanently failed in the dead letter queue (XQ), query:
 HGETALL dramatiq:default.XQ.msgs
 ```
 
-To query a list of missing blocks in a range, run:
+**Backfilling a list of blocks**
+
+Create a file containing a block per row, for example blocks.txt containing:
 ```
-psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t
+12500000
+12500001
+12500002
 ```
 
-To backfill missing blocks in a range, run:
+Then queue the blocks with
 ```
-psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t | ./mev block-list
+cat blocks.txt | ./mev block-list
 ```
 
 For more information on queues, see the [spec shared by dramatiq](https://github.com/Bogdanp/dramatiq/blob/24cbc0dc551797783f41b08ea461e1b5d23a4058/dramatiq/brokers/redis/dispatch.lua#L24-L43)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ For messages permanently failed in the dead letter queue (XQ), query:
 HGETALL dramatiq:default.XQ.msgs
 ```
 
+To query a list of missing blocks in a range, run:
+```
+psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t
+```
+
+To backfill missing blocks in a range, run:
+```
+psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t | ./mev block-list
+```
+
 For more information on queues, see the [spec shared by dramatiq](https://github.com/Bogdanp/dramatiq/blob/24cbc0dc551797783f41b08ea461e1b5d23a4058/dramatiq/brokers/redis/dispatch.lua#L24-L43)
 
 

--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import fileinput
 
 import click
 
@@ -90,6 +91,16 @@ async def inspect_many_blocks_command(
         before_block=before_block,
     )
 
+@cli.command()
+def enqueue_block_list_command():
+    from worker import (  # pylint: disable=import-outside-toplevel
+        inspect_many_blocks_task,
+    )
+
+    for block_string in fileinput.input():
+        block = int(block_string)
+        logger.info(f"Sending {block} to {block+1}")
+        inspect_many_blocks_task.send(block, block+1)
 
 @cli.command()
 @click.argument("after_block", type=int)

--- a/mev
+++ b/mev
@@ -45,6 +45,10 @@ case "$1" in
   listener)
         kubectl exec -ti deploy/mev-inspect -- ./listener $2
 	;;
+  block-list)
+        echo "Backfilling blocks from stdin"
+        kubectl exec -ti deploy/mev-inspect -- poetry run enqueue-block-list
+	;;
   backfill)
         start_block_number=$2
         end_block_number=$3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ build-backend = "poetry.core.masonry.api"
 inspect-block = 'cli:inspect_block_command'
 inspect-many-blocks = 'cli:inspect_many_blocks_command'
 enqueue-many-blocks = 'cli:enqueue_many_blocks_command'
+enqueue-block-list = 'cli:enqueue_block_list_command'
 fetch-block = 'cli:fetch_block_command'
 fetch-all-prices = 'cli:fetch_all_prices'
 


### PR DESCRIPTION
I noticed that my `./mev backfill $start $end` had some missing spots due to errors thrown by my RPC provider. I added this command line tool so I could create a list of missing blocks and enqueue them again.