### PR TITLE
add sandwich profit

### DIFF
--- a/alembic/versions/b26ab0051a88_add_profit_amount_column_to_sandwiches_.py
+++ b/alembic/versions/b26ab0051a88_add_profit_amount_column_to_sandwiches_.py
@@ -1,0 +1,27 @@
+"""add profit_amount column to sandwiches table
+
+Revision ID: b26ab0051a88
+Revises: 3c54832385e3
+Create Date: 2022-01-16 13:45:10.190969
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b26ab0051a88"
+down_revision = "3c54832385e3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "sandwiches", sa.Column("profit_token_address", sa.String(256), nullable=True)
+    )
+    op.add_column("sandwiches", sa.Column("profit_amount", sa.Numeric, nullable=True))
+
+
+def downgrade():
+    op.drop_column("sandwiches", "profit_token_address")
+    op.drop_column("sandwiches", "profit_amount")

--- a/mev_inspect/crud/sandwiches.py
+++ b/mev_inspect/crud/sandwiches.py
@@ -39,6 +39,8 @@ def write_sandwiches(
                 frontrun_swap_trace_address=sandwich.frontrun_swap.trace_address,
                 backrun_swap_transaction_hash=sandwich.backrun_swap.transaction_hash,
                 backrun_swap_trace_address=sandwich.backrun_swap.trace_address,
+                profit_token_address=sandwich.profit_token_address,
+                profit_amount=sandwich.profit_amount,
             )
         )
 

--- a/mev_inspect/models/sandwiches.py
+++ b/mev_inspect/models/sandwiches.py
@@ -14,3 +14,5 @@ class SandwichModel(Base):
     frontrun_swap_trace_address = Column(ARRAY(Integer), nullable=False)
     backrun_swap_transaction_hash = Column(String(256), nullable=False)
     backrun_swap_trace_address = Column(ARRAY(Integer), nullable=False)
+    profit_token_address = Column(String(256), nullable=False)
+    profit_amount = Column(Numeric, nullable=False)

--- a/mev_inspect/sandwiches.py
+++ b/mev_inspect/sandwiches.py
@@ -62,6 +62,9 @@ def _get_sandwich_starting_with_swap(
                         frontrun_swap=front_swap,
                         backrun_swap=other_swap,
                         sandwiched_swaps=sandwiched_swaps,
+                        profit_token_address=front_swap.token_in_address,
+                        profit_amount=other_swap.token_out_amount
+                        - front_swap.token_in_amount,
                     )
 
     return None

--- a/mev_inspect/schemas/sandwiches.py
+++ b/mev_inspect/schemas/sandwiches.py
@@ -11,3 +11,5 @@ class Sandwich(BaseModel):
     frontrun_swap: Swap
     backrun_swap: Swap
     sandwiched_swaps: List[Swap]
+    profit_token_address: str
+    profit_amount: int

--- a/tests/sandwiches/12775690.json
+++ b/tests/sandwiches/12775690.json
@@ -1,116 +1,120 @@
-[{
-    "block_number": 12775690,
-    "sandwicher_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
-    "frontrun_swap": {
-        "abi_name": "UniswapV2Pair",
-        "transaction_hash": "0x91a3abe5f3b806426542252820ba0ab6d56c098fdef6864ecaf4d352f64217a0",
-        "transaction_position": 2,
+[
+    {
         "block_number": 12775690,
-        "trace_address": [
-            0,
-            2
+        "sandwicher_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
+        "frontrun_swap": {
+            "abi_name": "UniswapV2Pair",
+            "transaction_hash": "0x91a3abe5f3b806426542252820ba0ab6d56c098fdef6864ecaf4d352f64217a0",
+            "transaction_position": 2,
+            "block_number": 12775690,
+            "trace_address": [
+                0,
+                2
+            ],
+            "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
+            "from_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
+            "to_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
+            "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "token_in_amount": 12108789017249529876,
+            "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+            "token_out_amount": 1114969767487478978357,
+            "protocol": null,
+            "error": null
+        },
+        "backrun_swap": {
+            "abi_name": "UniswapV2Pair",
+            "transaction_hash": "0xc300d1ff79d3901b58dc56489fc7d083a6c13d422bfc1425a0579379300c95a2",
+            "transaction_position": 7,
+            "block_number": 12775690,
+            "trace_address": [
+                0,
+                3
+            ],
+            "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
+            "from_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
+            "to_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
+            "token_in_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+            "token_in_amount": 1114969767487478978357,
+            "token_out_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "token_out_amount": 12158780499164852150,
+            "protocol": null,
+            "error": null
+        },
+        "sandwiched_swaps": [
+            {
+                "abi_name": "UniswapV2Pair",
+                "transaction_hash": "0x9b40deca1f53593b7631ca25485d0c6faf90279b9872845acfd5c98afb185934",
+                "transaction_position": 3,
+                "block_number": 12775690,
+                "trace_address": [
+                    3
+                ],
+                "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
+                "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
+                "to_address": "0x37e17e96736aee2ca809abd91e0f8744910ca19a",
+                "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "token_in_amount": 652974555369106606,
+                "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+                "token_out_amount": 60000000000000000000,
+                "protocol": null,
+                "error": null
+            },
+            {
+                "abi_name": "UniswapV2Pair",
+                "transaction_hash": "0xf8e45a291cdab5e456375e4d7df30771670d504835c9332b32114e5bc4e315f9",
+                "transaction_position": 4,
+                "block_number": 12775690,
+                "trace_address": [
+                    3
+                ],
+                "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
+                "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
+                "to_address": "0xd3b7ddf9eb72837f0ee3d1d30dec0e45fbdf79b1",
+                "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "token_in_amount": 300000000000000000,
+                "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+                "token_out_amount": 27561865602394087181,
+                "protocol": null,
+                "error": null
+            },
+            {
+                "abi_name": "UniswapV2Pair",
+                "transaction_hash": "0xdf63b22773b66cc41e00fd42c3b3c7f42912f87476ffe6d821e3f5c00284f00b",
+                "transaction_position": 5,
+                "block_number": 12775690,
+                "trace_address": [
+                    3
+                ],
+                "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
+                "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
+                "to_address": "0xcf99e104fdc46bea618d85ac5250067f19a56e41",
+                "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "token_in_amount": 125000000000000000,
+                "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+                "token_out_amount": 11483313070817976324,
+                "protocol": null,
+                "error": null
+            },
+            {
+                "abi_name": "UniswapV2Pair",
+                "transaction_hash": "0x1fe35f66e24f12bdb54a0d35934aac809c783710d998621b70116ea9f95f4f4f",
+                "transaction_position": 6,
+                "block_number": 12775690,
+                "trace_address": [
+                    3
+                ],
+                "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
+                "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
+                "to_address": "0xd7c9f3010efdff665ee72580ffa7b4141e56b17e",
+                "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "token_in_amount": 30000000000000000000,
+                "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
+                "token_out_amount": 2742522049933966038599,
+                "protocol": null,
+                "error": null
+            }
         ],
-        "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
-        "from_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
-        "to_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
-        "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-        "token_in_amount": 12108789017249529876,
-        "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-        "token_out_amount": 1114969767487478978357,
-        "protocol": null,
-        "error": null
-    },
-    "backrun_swap": {
-        "abi_name": "UniswapV2Pair",
-        "transaction_hash": "0xc300d1ff79d3901b58dc56489fc7d083a6c13d422bfc1425a0579379300c95a2",
-        "transaction_position": 7,
-        "block_number": 12775690,
-        "trace_address": [
-            0,
-            3
-        ],
-        "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
-        "from_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
-        "to_address": "0x000000000027d2efc283613d0c3e24a8b430c4d8",
-        "token_in_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-        "token_in_amount": 1114969767487478978357,
-        "token_out_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-        "token_out_amount": 12158780499164852150,
-        "protocol": null,
-        "error": null
-    },
-    "sandwiched_swaps": [
-        {
-            "abi_name": "UniswapV2Pair",
-            "transaction_hash": "0x9b40deca1f53593b7631ca25485d0c6faf90279b9872845acfd5c98afb185934",
-            "transaction_position": 3,
-            "block_number": 12775690,
-            "trace_address": [
-                3
-            ],
-            "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
-            "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
-            "to_address": "0x37e17e96736aee2ca809abd91e0f8744910ca19a",
-            "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-            "token_in_amount": 652974555369106606,
-            "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-            "token_out_amount": 60000000000000000000,
-            "protocol": null,
-            "error": null
-        },
-        {
-            "abi_name": "UniswapV2Pair",
-            "transaction_hash": "0xf8e45a291cdab5e456375e4d7df30771670d504835c9332b32114e5bc4e315f9",
-            "transaction_position": 4,
-            "block_number": 12775690,
-            "trace_address": [
-                3
-            ],
-            "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
-            "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
-            "to_address": "0xd3b7ddf9eb72837f0ee3d1d30dec0e45fbdf79b1",
-            "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-            "token_in_amount": 300000000000000000,
-            "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-            "token_out_amount": 27561865602394087181,
-            "protocol": null,
-            "error": null
-        },
-        {
-            "abi_name": "UniswapV2Pair",
-            "transaction_hash": "0xdf63b22773b66cc41e00fd42c3b3c7f42912f87476ffe6d821e3f5c00284f00b",
-            "transaction_position": 5,
-            "block_number": 12775690,
-            "trace_address": [
-                3
-            ],
-            "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
-            "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
-            "to_address": "0xcf99e104fdc46bea618d85ac5250067f19a56e41",
-            "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-            "token_in_amount": 125000000000000000,
-            "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-            "token_out_amount": 11483313070817976324,
-            "protocol": null,
-            "error": null
-        },
-        {
-            "abi_name": "UniswapV2Pair",
-            "transaction_hash": "0x1fe35f66e24f12bdb54a0d35934aac809c783710d998621b70116ea9f95f4f4f",
-            "transaction_position": 6,
-            "block_number": 12775690,
-            "trace_address": [
-                3
-            ],
-            "contract_address": "0xefb47fcfcad4f96c83d4ca676842fb03ef20a477",
-            "from_address": "0x03f7724180aa6b939894b5ca4314783b0b36b329",
-            "to_address": "0xd7c9f3010efdff665ee72580ffa7b4141e56b17e",
-            "token_in_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-            "token_in_amount": 30000000000000000000,
-            "token_out_address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
-            "token_out_amount": 2742522049933966038599,
-            "protocol": null,
-            "error": null
-        }
-    ]
-}]
+        "profit_token_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "profit_amount": 49991481915322274
+    }
+]


### PR DESCRIPTION
Adds `profit_amount` column to db and models. [A bit of analysis](https://calebeverett.github.io/mev-attacks/) to confirm it's calculated correctly.