### PR TITLE
Add prices fetch-range

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -119,8 +119,8 @@ def fetch_all_prices():
 
 
 @cli.command()
-@click.argument("after", type=datetime)
-@click.argument("before", type=datetime)
+@click.argument("after", type=click.DateTime(formats=["%Y-%m-%d", "%m-%d-%Y"]))
+@click.argument("before", type=click.DateTime(formats=["%Y-%m-%d", "%m-%d-%Y"]))
 def fetch_range(after: datetime, before: datetime):
     inspect_db_session = get_inspect_session()
 

--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from datetime import datetime
 
 import click
 
@@ -118,13 +119,13 @@ def fetch_all_prices():
 
 
 @cli.command()
-@click.argument("start", type=int)
-@click.argument("end", type=int)
-def fetch_range(start: int, end: int):
+@click.argument("after", type=datetime)
+@click.argument("before", type=datetime)
+def fetch_range(after: datetime, before: datetime):
     inspect_db_session = get_inspect_session()
 
     logger.info("Fetching prices")
-    prices = fetch_prices_range(start, end)
+    prices = fetch_prices_range(after, before)
 
     logger.info("Writing prices")
     write_prices(inspect_db_session, prices)

--- a/cli.py
+++ b/cli.py
@@ -8,7 +8,7 @@ from mev_inspect.concurrency import coro
 from mev_inspect.crud.prices import write_prices
 from mev_inspect.db import get_inspect_session, get_trace_session
 from mev_inspect.inspector import MEVInspector
-from mev_inspect.prices import fetch_prices
+from mev_inspect.prices import fetch_prices, fetch_prices_range
 
 RPC_URL_ENV = "RPC_URL"
 
@@ -112,6 +112,19 @@ def fetch_all_prices():
 
     logger.info("Fetching prices")
     prices = fetch_prices()
+
+    logger.info("Writing prices")
+    write_prices(inspect_db_session, prices)
+
+
+@cli.command()
+@click.argument("start", type=int)
+@click.argument("end", type=int)
+def fetch_range(start: int, end: int):
+    inspect_db_session = get_inspect_session()
+
+    logger.info("Fetching prices")
+    prices = fetch_prices_range(start, end)
 
     logger.info("Writing prices")
     write_prices(inspect_db_session, prices)

--- a/mev
+++ b/mev
@@ -82,7 +82,14 @@ case "$1" in
                 kubectl exec -ti deploy/mev-inspect -- \
                     poetry run fetch-all-prices
             ;;
-          *)
+          fetch-range)
+                start=$2
+                end=$3
+                echo "Running price fetch-range"
+                kubectl exec -ti deploy/mev-inspect -- \
+                    poetry run fetch-range $start $end
+            ;;
+            *)
             echo "prices usage: "$1" {fetch-all}"
             exit 1
         esac

--- a/mev
+++ b/mev
@@ -83,11 +83,11 @@ case "$1" in
                     poetry run fetch-all-prices
             ;;
           fetch-range)
-                start=$2
-                end=$3
+                after=$2
+                before=$3
                 echo "Running price fetch-range"
                 kubectl exec -ti deploy/mev-inspect -- \
-                    poetry run fetch-range $start $end
+                    poetry run fetch-range $after $before
             ;;
             *)
             echo "prices usage: "$1" {fetch-all}"

--- a/mev_inspect/prices.py
+++ b/mev_inspect/prices.py
@@ -20,7 +20,32 @@ def fetch_prices() -> List[Price]:
         price_time_series = price_data["prices"]
 
         for entry in price_time_series:
-            timestamp = dt.fromtimestamp(entry[0] / 100)
+            timestamp = dt.fromtimestamp(entry[0] / 1000)
+            token_price = entry[1]
+            prices.append(
+                Price(
+                    timestamp=timestamp,
+                    usd_price=token_price,
+                    token_address=token_address,
+                )
+            )
+
+    return prices
+
+
+def fetch_prices_range(start: int, end: int) -> List[Price]:
+
+    cg = CoinGeckoAPI()
+    prices = []
+
+    for token_address in TOKEN_ADDRESSES:
+        price_data = cg.get_coin_market_chart_range_by_id(
+            COINGECKO_ID_BY_ADDRESS[token_address], "usd", start, end
+        )
+        price_time_series = price_data["prices"]
+
+        for entry in price_time_series:
+            timestamp = dt.fromtimestamp(entry[0] / 1000)
             token_price = entry[1]
             prices.append(
                 Price(

--- a/mev_inspect/prices.py
+++ b/mev_inspect/prices.py
@@ -7,11 +7,11 @@ from mev_inspect.schemas.prices import COINGECKO_ID_BY_ADDRESS, TOKEN_ADDRESSES,
 
 
 def fetch_prices() -> List[Price]:
-    cg = CoinGeckoAPI()
+    coingecko_api = CoinGeckoAPI()
     prices = []
 
     for token_address in TOKEN_ADDRESSES:
-        coingecko_price_data = cg.get_coin_market_chart_by_id(
+        coingecko_price_data = coingecko_api.get_coin_market_chart_by_id(
             id=COINGECKO_ID_BY_ADDRESS[token_address],
             vs_currency="usd",
             days="max",
@@ -23,13 +23,13 @@ def fetch_prices() -> List[Price]:
 
 
 def fetch_prices_range(after: datetime, before: datetime) -> List[Price]:
-    cg = CoinGeckoAPI()
+    coingecko_api = CoinGeckoAPI()
     prices = []
     after_unix = int(after.timestamp())
     before_unix = int(before.timestamp())
 
     for token_address in TOKEN_ADDRESSES:
-        coingecko_price_data = cg.get_coin_market_chart_range_by_id(
+        coingecko_price_data = coingecko_api.get_coin_market_chart_range_by_id(
             COINGECKO_ID_BY_ADDRESS[token_address], "usd", after_unix, before_unix
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ inspect-many-blocks = 'cli:inspect_many_blocks_command'
 enqueue-many-blocks = 'cli:enqueue_many_blocks_command'
 fetch-block = 'cli:fetch_block_command'
 fetch-all-prices = 'cli:fetch_all_prices'
+fetch-range = 'cli:fetch_range'
 
 [tool.black]
 exclude = '''


### PR DESCRIPTION
## Overview
Add prices-range command that fills prices in a specified time range

## Usage
Fetch prices for all tokens form 01-01-2022 to 01-19-2022:
```
./mev prices fetch-range 1641013200 1642568400
```

## Note
- Timestamps must be in UNIX integer timestamp format
- Minutely data will be used for duration within 1 day, Hourly data will be used for duration between 1 day and 90 days, Daily data will be used for duration above 90 days.