### PR TITLE
Allow sandwiches with large differences. Explicitly filter uniswap routers

### DIFF
--- a/mev_inspect/sandwiches.py
+++ b/mev_inspect/sandwiches.py
@@ -2,9 +2,9 @@ from typing import List, Optional
 
 from mev_inspect.schemas.sandwiches import Sandwich
 from mev_inspect.schemas.swaps import Swap
-from mev_inspect.utils import equal_within_percent
 
-SANDWICH_IN_OUT_MAX_PERCENT_DIFFERENCE = 0.01
+UNISWAP_V2_ROUTER = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
+UNISWAP_V3_ROUTER = "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45"
 
 
 def get_sandwiches(swaps: List[Swap]) -> List[Sandwich]:
@@ -34,6 +34,9 @@ def _get_sandwich_starting_with_swap(
     sandwicher_address = front_swap.to_address
     sandwiched_swaps = []
 
+    if sandwicher_address in [UNISWAP_V2_ROUTER, UNISWAP_V3_ROUTER]:
+        return None
+
     for other_swap in rest_swaps:
         if other_swap.transaction_hash == front_swap.transaction_hash:
             continue
@@ -48,11 +51,6 @@ def _get_sandwich_starting_with_swap(
             elif (
                 other_swap.token_out_address == front_swap.token_in_address
                 and other_swap.token_in_address == front_swap.token_out_address
-                and equal_within_percent(
-                    other_swap.token_in_amount,
-                    front_swap.token_out_amount,
-                    SANDWICH_IN_OUT_MAX_PERCENT_DIFFERENCE,
-                )
                 and other_swap.from_address == sandwicher_address
             ):
                 if len(sandwiched_swaps) > 0:


### PR DESCRIPTION
An example sandwich where the bot takes profit on the way back instead of sending in the same amount:
Front - https://etherscan.io/tx/0x499107bb120534cf07c5d3353bcfc9d7b5de900ea1776be7fc72013986e09e2b
Middle - https://etherscan.io/tx/0xb9a8904b519f52a92163d5387f3e726f17df904fd1c6c14fd0ab9ddde993f5e3
Back - https://etherscan.io/tx/0xed43ef32ce41f00cf1fc861e1b7c1e8aa21ebbb0b97810b1b87f6314aea437f7

Three swaps in different directions from the uniswap routers also frequently shows as a sandwich without the rule, so removing them explicitly