### PR TITLE
Change nft_trades primary key to include block_number

### DIFF
--- a/alembic/versions/5c5375de15fd_add_block_number_to_nft_trades_primary_.py
+++ b/alembic/versions/5c5375de15fd_add_block_number_to_nft_trades_primary_.py
@@ -1,0 +1,32 @@
+"""Add block_number to nft_trades primary key
+
+Revision ID: 5c5375de15fd
+Revises: e616420acd18
+Create Date: 2022-01-21 15:27:57.790340
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5c5375de15fd"
+down_revision = "e616420acd18"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE nft_trades DROP CONSTRAINT nft_trades_pkey")
+    op.create_primary_key(
+        "nft_trades_pkey",
+        "nft_trades",
+        ["block_number", "transaction_hash", "trace_address"],
+    )
+
+
+def downgrade():
+    op.execute("ALTER TABLE nft_trades DROP CONSTRAINT nft_trades_pkey")
+    op.create_primary_key(
+        "nft_trades_pkey",
+        "nft_trades",
+        ["transaction_hash", "trace_address"],
+    )


### PR DESCRIPTION
All main tables should have block number as a primary key

Currently deleting from this table during inspection is our largest CPU usage because it has to search the table each time