### PR TITLE
Fix alchemy endpoint json rpc parameters

### DIFF
--- a/mev_inspect/block.py
+++ b/mev_inspect/block.py
@@ -107,7 +107,7 @@ async def _fetch_block_timestamp(w3, block_number: int) -> int:
 
 
 async def _fetch_block_receipts(w3, block_number: int) -> List[Receipt]:
-    receipts_json = await w3.eth.get_block_receipts(block_number)
+    receipts_json = await w3.eth.get_block_receipts(hex(block_number))
     return [Receipt(**receipt) for receipt in receipts_json]
 
 

--- a/mev_inspect/fees.py
+++ b/mev_inspect/fees.py
@@ -2,7 +2,7 @@ from web3 import Web3
 
 
 async def fetch_base_fee_per_gas(w3: Web3, block_number: int) -> int:
-    base_fees = await w3.eth.fee_history(1, block_number)
+    base_fees = await w3.eth.fee_history(1, block_number, [])
     base_fees_per_gas = base_fees["baseFeePerGas"]
     if len(base_fees_per_gas) == 0:
         raise RuntimeError("Unexpected error - no fees returned")


### PR DESCRIPTION
When running the following command (present in the ```README.md```):
```bash
./mev inspect 12914944
```
We get the following output:
```bash
Inspecting block 12914944
Skipping virtualenv creation, as specified in config file.
ERROR:mev_inspect.retry:Request for method eth_getBlockReceipts, params: (12914944,), retrying: 0/5
ERROR:mev_inspect.retry:Request for method eth_feeHistory, params: (1, '0xc51100', None), retrying: 0/5
ERROR:mev_inspect.retry:Request for method eth_feeHistory, params: (1, '0xc51100', None), retrying: 1/5
ERROR:mev_inspect.retry:Request for method eth_getBlockReceipts, params: (12914944,), retrying: 1/5
```
These errors are a result of bad parameters passed to the json-rpc endpoint on some nodes. In my case this was an alchemy node.