### PR TITLE
Create low and high priority queues. Put export on high priority, backfill on low

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13,8 +13,10 @@ from mev_inspect.inspector import MEVInspector
 from mev_inspect.prices import fetch_prices, fetch_prices_range
 from mev_inspect.queue.broker import connect_broker
 from mev_inspect.queue.tasks import (
-    BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY,
-    LIVE_EXPORT_BLOCK_PRIORITY,
+    HIGH_PRIORITY,
+    HIGH_PRIORITY_QUEUE,
+    LOW_PRIORITY,
+    LOW_PRIORITY_QUEUE,
     export_block_task,
     inspect_many_blocks_task,
 )
@@ -110,7 +112,8 @@ def enqueue_many_blocks_command(start_block: int, end_block: int, batch_size: in
     inspect_many_blocks_actor = dramatiq.actor(
         inspect_many_blocks_task,
         broker=broker,
-        priority=BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY,
+        queue_name=LOW_PRIORITY_QUEUE,
+        priority=LOW_PRIORITY,
     )
 
     if start_block < end_block:
@@ -147,7 +150,10 @@ def fetch_all_prices():
 def enqueue_s3_export(block_number: int):
     broker = connect_broker()
     export_actor = dramatiq.actor(
-        export_block_task, broker=broker, priority=LIVE_EXPORT_BLOCK_PRIORITY
+        export_block_task,
+        broker=broker,
+        queue_name=HIGH_PRIORITY_QUEUE,
+        priority=HIGH_PRIORITY,
     )
     logger.info(f"Sending block {block_number} export to queue")
     export_actor.send(block_number)

--- a/listener.py
+++ b/listener.py
@@ -15,7 +15,11 @@ from mev_inspect.db import get_inspect_session, get_trace_session
 from mev_inspect.inspector import MEVInspector
 from mev_inspect.provider import get_base_provider
 from mev_inspect.queue.broker import connect_broker
-from mev_inspect.queue.tasks import export_block_task
+from mev_inspect.queue.tasks import (
+    HIGH_PRIORITY,
+    HIGH_PRIORITY_QUEUE,
+    export_block_task,
+)
 from mev_inspect.signal_handler import GracefulKiller
 
 logging.basicConfig(filename="listener.log", filemode="a", level=logging.INFO)
@@ -41,7 +45,12 @@ async def run():
     trace_db_session = get_trace_session()
 
     broker = connect_broker()
-    export_actor = dramatiq.actor(export_block_task, broker=broker)
+    export_actor = dramatiq.actor(
+        export_block_task,
+        broker=broker,
+        queue_name=HIGH_PRIORITY_QUEUE,
+        priority=HIGH_PRIORITY,
+    )
 
     inspector = MEVInspector(rpc)
     base_provider = get_base_provider(rpc)

--- a/mev_inspect/queue/tasks.py
+++ b/mev_inspect/queue/tasks.py
@@ -9,11 +9,11 @@ from .middleware import DbMiddleware, InspectorMiddleware
 logger = logging.getLogger(__name__)
 
 
-# when we have export backfill,
-# create a separate actor for backfill export
-# and set to same priority as backfill inspect
-LIVE_EXPORT_BLOCK_PRIORITY = 0
-BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY = 1
+HIGH_PRIORITY_QUEUE = "high"
+LOW_PRIORITY_QUEUE = "low"
+
+HIGH_PRIORITY = 0
+LOW_PRIORITY = 1
 
 
 def inspect_many_blocks_task(

--- a/mev_inspect/queue/tasks.py
+++ b/mev_inspect/queue/tasks.py
@@ -9,6 +9,12 @@ from .middleware import DbMiddleware, InspectorMiddleware
 logger = logging.getLogger(__name__)
 
 
+# create a separate actor for backfill export
+# set to same priority as backfill inspect
+LIVE_EXPORT_BLOCK_PRIORITY = 1
+BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY = 0
+
+
 def inspect_many_blocks_task(
     after_block: int,
     before_block: int,

--- a/mev_inspect/queue/tasks.py
+++ b/mev_inspect/queue/tasks.py
@@ -9,10 +9,11 @@ from .middleware import DbMiddleware, InspectorMiddleware
 logger = logging.getLogger(__name__)
 
 
+# when we have export backfill,
 # create a separate actor for backfill export
-# set to same priority as backfill inspect
-LIVE_EXPORT_BLOCK_PRIORITY = 1
-BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY = 0
+# and set to same priority as backfill inspect
+LIVE_EXPORT_BLOCK_PRIORITY = 0
+BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY = 1
 
 
 def inspect_many_blocks_task(

--- a/worker.py
+++ b/worker.py
@@ -10,7 +10,12 @@ from mev_inspect.queue.middleware import (
     DbMiddleware,
     InspectorMiddleware,
 )
-from mev_inspect.queue.tasks import export_block_task, inspect_many_blocks_task
+from mev_inspect.queue.tasks import (
+    BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY,
+    LIVE_EXPORT_BLOCK_PRIORITY,
+    export_block_task,
+    inspect_many_blocks_task,
+)
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
@@ -20,5 +25,5 @@ broker.add_middleware(AsyncMiddleware())
 broker.add_middleware(InspectorMiddleware(os.environ["RPC_URL"]))
 dramatiq.set_broker(broker)
 
-dramatiq.actor(inspect_many_blocks_task)
-dramatiq.actor(export_block_task)
+dramatiq.actor(inspect_many_blocks_task, priority=BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY)
+dramatiq.actor(export_block_task, priority=LIVE_EXPORT_BLOCK_PRIORITY)

--- a/worker.py
+++ b/worker.py
@@ -11,8 +11,8 @@ from mev_inspect.queue.middleware import (
     InspectorMiddleware,
 )
 from mev_inspect.queue.tasks import (
-    BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY,
-    LIVE_EXPORT_BLOCK_PRIORITY,
+    HIGH_PRIORITY_QUEUE,
+    LOW_PRIORITY_QUEUE,
     export_block_task,
     inspect_many_blocks_task,
 )
@@ -25,5 +25,5 @@ broker.add_middleware(AsyncMiddleware())
 broker.add_middleware(InspectorMiddleware(os.environ["RPC_URL"]))
 dramatiq.set_broker(broker)
 
-dramatiq.actor(inspect_many_blocks_task, priority=BACKFILL_INSPECT_MANY_BLOCKS_PRIORITY)
-dramatiq.actor(export_block_task, priority=LIVE_EXPORT_BLOCK_PRIORITY)
+dramatiq.actor(inspect_many_blocks_task, queue_name=HIGH_PRIORITY_QUEUE)
+dramatiq.actor(export_block_task, queue_name=LOW_PRIORITY_QUEUE)


### PR DESCRIPTION
## Issue

We want to export blocks to S3 as we're writing new blocks live

If we're running a large backfill as well, these live exports will be placed on back of the queue

Because the queue is ordered by append time, we have to wait for the backfill to finish before the exports are processed

## The goal

Prioritize live exports over backfills

## This PR

Adds high and low priority queues + priorities

Dramatiq is a little sketchy here.
- Redis backend doesn't have a sense of priority (maybe a good reason to switch to RabbitMQ which does, or even fully to Kafka to skip a step)
- The worker does order by priority for messages it pulls off to work on
- Here we create 2 queue levels - the worker will by default subscribe to messages from both and create separate threads for each
- When it pulls messages off both, it will always prefer messages from the high priority queue

This isn't an incredibly durable solution (if the high priority queue has a ton in it, I don't know that we'll still consistently prioritize it - depends on how often the worker pulls off v. consumes what it has)

But it's sufficient for our use where the high priority is relatively small

## Testing

Using 1 worker locally
Loaded 100 blocks to backfill and let it start progressing
Loaded 3 export blocks to the queue next

Verified that after the current backfill batch was finished, the worker consumed the export tasks then continued backfill

<img width="961" alt="image" src="https://user-images.githubusercontent.com/5885679/154113104-f5593238-f974-40e8-9b42-3e9a30fd0bb4.png">
