### PR TITLE
Enqueue a list of blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,18 @@ DEL dramatiq:default.DQ.msgs
 
 For more information on queues, see the [spec shared by dramatiq](https://github.com/Bogdanp/dramatiq/blob/24cbc0dc551797783f41b08ea461e1b5d23a4058/dramatiq/brokers/redis/dispatch.lua#L24-L43)
 
-To query a list of missing blocks in a range, run:
+**Backfilling a list of blocks**
+
+Create a file containing a block per row, for example blocks.txt containing:
 ```
-psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t
+12500000
+12500001
+12500002
 ```
 
-To backfill missing blocks in a range, run:
+Then queue the blocks with
 ```
-psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t | ./mev block-list
+cat blocks.txt | ./mev block-list
 ```
 
 To watch the logs for a given worker pod, take its pod name using the above, then run:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ DEL dramatiq:default.DQ.msgs
 
 For more information on queues, see the [spec shared by dramatiq](https://github.com/Bogdanp/dramatiq/blob/24cbc0dc551797783f41b08ea461e1b5d23a4058/dramatiq/brokers/redis/dispatch.lua#L24-L43)
 
+To query a list of missing blocks in a range, run:
+```
+psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t
+```
+
+To backfill missing blocks in a range, run:
+```
+psql postgresql://postgres:password@localhost:5432/mev_inspect -c "select generate_series(13999471, 13999571) EXCEPT (select distinct block_number from blocks)" --csv -t | ./mev block-list
+```
 
 To watch the logs for a given worker pod, take its pod name using the above, then run:
 ```

--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import fileinput
 from datetime import datetime
 
 import click
@@ -102,6 +103,16 @@ async def inspect_many_blocks_command(
         before_block=before_block,
     )
 
+@cli.command()
+def enqueue_block_list_command():
+    from worker import (  # pylint: disable=import-outside-toplevel
+        inspect_many_blocks_task,
+    )
+
+    for block_string in fileinput.input():
+        block = int(block_string)
+        logger.info(f"Sending {block} to {block+1}")
+        inspect_many_blocks_task.send(block, block+1)
 
 @cli.command()
 @click.argument("start_block", type=int)

--- a/mev
+++ b/mev
@@ -45,6 +45,10 @@ case "$1" in
   listener)
         kubectl exec -ti deploy/mev-inspect -- ./listener $2
 	;;
+  block-list)
+        echo "Backfilling blocks from stdin"
+        kubectl exec -ti deploy/mev-inspect -- poetry run enqueue-block-list
+	;;
   backfill)
         after_block_number=$2
         before_block_number=$3

--- a/mev
+++ b/mev
@@ -47,7 +47,7 @@ case "$1" in
 	;;
   block-list)
         echo "Backfilling blocks from stdin"
-        kubectl exec -ti deploy/mev-inspect -- poetry run enqueue-block-list
+        kubectl exec -i deploy/mev-inspect -- poetry run enqueue-block-list
 	;;
   backfill)
         after_block_number=$2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ build-backend = "poetry.core.masonry.api"
 inspect-block = 'cli:inspect_block_command'
 inspect-many-blocks = 'cli:inspect_many_blocks_command'
 enqueue-many-blocks = 'cli:enqueue_many_blocks_command'
+enqueue-block-list = 'cli:enqueue_block_list_command'
 fetch-block = 'cli:fetch_block_command'
 fetch-all-prices = 'cli:fetch_all_prices'
 fetch-range = 'cli:fetch_range'


### PR DESCRIPTION
## What does this PR do?

Adds support for enqueing a list

## Related issue

Rebases and runs pre-commit for this https://github.com/flashbots/mev-inspect-py/pull/227


## Testing

Verified it enqueues a list of blocks locally and that they're processed by the worker

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
