### PR TITLE
fix check sandwicher against correct uniswap routers

### DIFF
--- a/mev_inspect/sandwiches.py
+++ b/mev_inspect/sandwiches.py
@@ -3,8 +3,9 @@ from typing import List, Optional
 from mev_inspect.schemas.sandwiches import Sandwich
 from mev_inspect.schemas.swaps import Swap
 
-UNISWAP_V2_ROUTER = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
-UNISWAP_V3_ROUTER = "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45"
+UNISWAP_V2_ROUTER = "0x7a250d5630b4cf539739df2c5dacb4c659f2488d"
+UNISWAP_V3_ROUTER = "0xe592427a0aece92de3edee1f18e0157c05861564"
+UNISWAP_V3_ROUTER_2 = "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45"
 
 
 def get_sandwiches(swaps: List[Swap]) -> List[Sandwich]:
@@ -34,7 +35,11 @@ def _get_sandwich_starting_with_swap(
     sandwicher_address = front_swap.to_address
     sandwiched_swaps = []
 
-    if sandwicher_address in [UNISWAP_V2_ROUTER, UNISWAP_V3_ROUTER]:
+    if sandwicher_address in [
+        UNISWAP_V2_ROUTER,
+        UNISWAP_V3_ROUTER,
+        UNISWAP_V3_ROUTER_2,
+    ]:
         return None
 
     for other_swap in rest_swaps:


### PR DESCRIPTION
## What does this PR do?

The `sandwich.sandwicher_address` should not be Uniswap V2 Router, V3 Router, or V3 Router 2. 

Fixes an issue where the `sandwicher_address` was checked agains the V2 Router as `0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D` when it should check against `0x7a250d5630b4cf539739df2c5dacb4c659f2488d` because the `sandwicher_address` is always lower-case

Rename `UNISWAP_V3_ROUTER` to `UNISWAP_V3_ROUTER_2` to be semantically correct

Add `UNISWAP_V3_ROUTER` with the correct address `0xe592427a0aece92de3edee1f18e0157c05861564`

## Related issue

https://github.com/flashbots/mev-inspect-py/issues/280

## Testing

What testing was performed to verify this works? Unit tests are a big plus!

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
