### PR TITLE
add blocks to export

### DIFF
--- a/mev_inspect/s3_export.py
+++ b/mev_inspect/s3_export.py
@@ -21,6 +21,7 @@ supported_tables = [
     "liquidations",
     "sandwiches",
     "sandwiched_swaps",
+    "blocks",
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## What does this PR do?

Include the blocks table in the exports to include the block timestamp

## Testing

What testing was performed to verify this works? Unit tests are a big plus!

## Checklist before merging
- [X] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [X] Installed and ran pre-commit hooks
- [X] All tests pass with `./mev test`
