### PR TITLE
add logging for the currently used rpc node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: v0.910
     hooks:
       - id: 'mypy'
+        language_version: python3.9
         additional_dependencies:
           - 'pydantic'
           - 'types-requests'

--- a/cli.py
+++ b/cli.py
@@ -41,6 +41,7 @@ async def inspect_block_command(block_number: int, rpc: str):
     trace_db_session = get_trace_session()
 
     inspector = MEVInspector(rpc)
+    logger.info(f"Using the RPC node {rpc}")
 
     await inspector.inspect_single_block(
         inspect_db_session=inspect_db_session,
@@ -94,6 +95,8 @@ async def inspect_many_blocks_command(
         max_concurrency=max_concurrency,
         request_timeout=request_timeout,
     )
+    logger.info(f"Using the RPC node {rpc}")
+
     await inspector.inspect_many_blocks(
         inspect_db_session=inspect_db_session,
         trace_db_session=trace_db_session,


### PR DESCRIPTION
## What does this PR do?

Adds simple logging to see the currently used RPC NODE in the logging/stdouts

## Related issue

Discord server/mev-inspect-py, plus I updated the .pre-commit-hook because mypy was failing, it needed a path to the executable for the env, naimly **language_version: python3.9**

If there isn't already an open issue, create an issue first. This will be our home for discussing the problem itself.

## Testing

Tested on Ubuntu 20.04, Python3.9 (system version)

What testing was performed to verify this works? Unit tests are a big plus!

## Checklist before merging
- [ ] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [ ] Installed and ran pre-commit hooks
- [ ] All tests pass with `./mev test`
