### PR TITLE
Filter out failed transactions before classification

### DIFF
--- a/mev_inspect/block.py
+++ b/mev_inspect/block.py
@@ -35,6 +35,12 @@ async def create_from_block_number(
         _find_or_fetch_base_fee_per_gas(w3, block_number, trace_db_session),
     )
 
+    # filter out failed transactions
+    failed_transactions = set(receipt.transaction_hash
+                              for receipt in receipts if receipt.status == 0)
+    receipts = [receipt for receipt in receipts if receipt.transaction_hash not in failed_transactions]
+    traces = [trace for trace in traces if trace.transaction_hash not in failed_transactions]
+
     miner_address = _get_miner_address_from_traces(traces)
 
     return Block(

--- a/mev_inspect/schemas/receipts.py
+++ b/mev_inspect/schemas/receipts.py
@@ -15,6 +15,7 @@ class Receipt(CamelModel):
     effective_gas_price: int
     cumulative_gas_used: int
     to: Optional[str]
+    status: int
 
     @validator(
         "block_number",
@@ -22,6 +23,7 @@ class Receipt(CamelModel):
         "gas_used",
         "effective_gas_price",
         "cumulative_gas_used",
+        "status",
         pre=True,
     )
     def maybe_hex_to_int(v):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,6 +23,9 @@ def load_test_block(block_number: int) -> Block:
 
     with open(block_path, "r") as block_file:
         block_json = json.load(block_file)
+        for item in block_json["receipts"]:
+            if "status" not in item:
+                item["status"] = "0x1"
         return Block(
             **{
                 **defaults,


### PR DESCRIPTION
## What does this PR do?

Filter out failed transactions before classification

## Related issue

#301

## Testing

Cases in #301 

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`

