### PR TITLE
feat: add ubuntu deployment script

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# bash script to commit in accordance with the branch name
+# usage: ./scripts/commit.sh
+branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+branch="${branch##*feat/}"
+branch="${branch//\_/ }"
+issue_number="${branch//Issue\-/}"
+title=$( cut -d ' ' -f 2- <<< "$issue_number" )
+issue_number=$( cut -d ' ' -f 1 <<< "$issue_number" )
+commit_message="feat: $title Closes #$issue_number"
+git commit -sam "$commit_message"

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -4,8 +4,8 @@
 branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 branch="${branch##*feat/}"
 branch="${branch//\_/ }"
-issue_number="${branch//Issue\-/}"
+issue_number="${branch//issue\-/}"
 title=$( cut -d ' ' -f 2- <<< "$issue_number" )
 issue_number=$( cut -d ' ' -f 1 <<< "$issue_number" )
-commit_message="feat: $title Closes #$issue_number"
+commit_message="feat: $title - closes #$issue_number"
 git commit -sam "$commit_message"

--- a/scripts/commit_and_push.sh
+++ b/scripts/commit_and_push.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+#  commits and push
+branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+./scripts/commit.sh
+git push --set-upstream origin $branch

--- a/scripts/create_new_branch.sh
+++ b/scripts/create_new_branch.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# bash script to create a new branch that respects the library standard
+#### ./scripts/create_new_branch.sh "[FEAT] - Implement instrument types #14"
+#### ./scripts/create_new_branch.sh "[FEAT] Implement instrument types #14"
+#### ./scripts/create_new_branch.sh "[FEAT] - Implement instrument types#14"
+base_issue=$1
+issue_number=${base_issue##*#}
+issue="${base_issue%%#*}"
+issue="${issue//\[FEAT\] \- /}"
+issue="${issue/\[FEAT\] /}"
+issue="${issue/\[FEAT\]/}"
+issue="${issue// /\_}"
+branch_name="feat/issue-$issue_number ${issue,,}"
+branch_name="${branch_name// /\_}"
+last_char="${branch_name: -1}"
+if [ "$last_char" = "_" ]
+then
+  branch_name=${branch_name::-1}
+fi
+git checkout -b $branch_name
+
+

--- a/scripts/prepare_instance.sh
+++ b/scripts/prepare_instance.sh
@@ -1,0 +1,55 @@
+# Update the dependencies.
+sudo apt-get update &&
+
+# Install Docker
+sudo apt install apt-transport-https ca-certificates curl software-properties-common -y &&
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" &&
+sudo apt install docker-ce -y &&
+
+# Install minikube
+sudo apt install -y curl wget apt-transport-https -y &&
+wget https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 &&
+sudo cp minikube-linux-amd64 /usr/local/bin/minikube &&
+sudo chmod +x /usr/local/bin/minikube &&
+minikube version &&
+
+# Install kubectl
+sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg &&
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list &&
+sudo apt-get update &&
+sudo apt-get install -y kubelet kubeadm kubectl &&
+sudo apt-mark hold kubelet kubeadm kubectl &&
+
+# Install Kind.
+# curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.17.0/kind-$(uname)-amd64" &&
+# chmod +x ./kind &&
+# sudo mv ./kind /usr/local/bin/kind &&
+
+# Install pip
+sudo apt install python3-pip -y &&
+
+# Install postgres lib
+sudo apt-get install -y libpq-dev &&
+
+# Install go
+rm -rf /usr/local/go ; wget https://go.dev/dl/go1.19.4.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.19.4.linux-amd64.tar.gz &&
+export PATH=$PATH:/usr/local/go/bin &&
+
+# Install tilt
+curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash &&
+
+# Install poetry
+curl -sSL https://install.python-poetry.org | python3 - &&
+export PATH=$HOME/.local/bin:$PATH &&
+
+# Clone the repository and prepare the enviro nment
+git clone https://github.com/IlluvatarEru/mev-inspect-py.git &&
+cd mev-inspect-py &&
+python3 -m pip install cytoolz &&
+poetry install
+
+echo -e "\nexport PATH=$HOME/.local/bin:$PATH" >> $HOME/.bashrc &&
+echo -e "\nexport PATH=$PATH:/usr/local/go/bin" >> $HOME/.bashrc &&
+
+echo -e "\nAt this point, think about running the reset command before using mev-inspect-py\n"


### PR DESCRIPTION
## What does this PR do?

This PR adds a script used to prepare an ubuntu instance when the full analysis will be performed.
It installs:
- Docker
- Minikube (the commands for kind are also provided, but commented)
- Kube tools
- Python utils (pip, cytoolz)
- go
- Tilt
- Poetry
- The mev-inspect-py repository

## Related issue

Link to the issue this PR addresses.

If there isn't already an open issue, create an issue first. This will be our home for discussing the problem itself.

## Testing

I ran the script on a Scaleway ubuntu instance, and it worked. The test was made on the polygon branch.

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
