### PR TITLE
remove repeated swaps with the same pool from arb calcs

### DIFF
--- a/mev_inspect/arbitrages.py
+++ b/mev_inspect/arbitrages.py
@@ -163,6 +163,8 @@ def _get_all_start_end_swaps(swaps: List[Swap]) -> List[Tuple[Swap, List[Swap]]]
             if (
                 potential_start_swap.token_in_address
                 == potential_end_swap.token_out_address
+                and potential_start_swap.contract_address
+                != potential_end_swap.contract_address
                 and potential_start_swap.from_address == potential_end_swap.to_address
                 and not potential_start_swap.from_address in pool_addrs
             ):


### PR DESCRIPTION
## What does this PR do?

This PR modifies the algorithm for identifying arbitrages from transactions containing multiple swaps, ensuring that the the first and last transactions in the chain do not use the same AMM pools. Consider the following example swap sequence resulting in an increased WETH balance:

WETH -> MKR
MKR -> UNI
UNI -> COMP
COMP -> MKR
MKR -> WETH

In this sequence the initial conversion from MKR to WETH and the final conversion from WETH back to MKR are not part of the arbitrage. Rather the searcher has exploited an imbalance in the relative pricings of MKR/UNI, UNI/COMP and COMP/MKR to extract a greater quantity of MKR than they supplied. However, the searcher did not initially hold (or wish to hold) MKR, so they completed a swap in using the WETH/MKR pool, and used the same pool to swap back out to WETH after the arbitrage. In most cases the same result would be achieved by borrowing the required MKR using a flashloan. However, in some cases a flashloan may not be available so the above swap-in/swap-out methodology would be employed.

The WETH/MKR swap in/out used here is not part of the arbitrage, it is merely a means for the searcher to access an arbitrage opportunity which exists between token pairs the searcher does not initially hold. Indeed the WETH/MKR swaps are not strictly required to exploit the arbitrage and only impose a cost on its exploitation (a MKR holder would succeed in extracting greater value than a searcher who holds only WETH). Therefore the gross value extracted here should be considered to be in MKR, and the WETH/MKR swaps should be excluded from the arbitrage swap chain.

## Related issue

Fixing this inaccuracy in the way some arbitrages are calculated has the side benefit of fixing [issue 323](https://github.com/flashbots/mev-inspect-py/issues/323), in which some non-arbitrage transactions are erroneously picked up by the arbitrage classifier and cause the arbitrage routing algorithm to fail to terminate.

## Testing

Verified that block 16330258 is now processed successfully.

In addition to the existing arbitrage unit tests, the modified algorithm was tested on 10,000 blocks starting from block 16,000,000. The change in extracted value (gross usd profit) as recorded in the mev_summary table was then compared before and after using the following query: 

`SELECT sum(gross_profit_usd) FROM mev_summary WHERE block_number BETWEEN 16000000 AND 16009999;`

Using the original algorithm, this query returned USD 63,022.26
Using the algorithm as updated by this PR, the query returned USD 63,200.89

Implying an approximately $180 increase in reported extracted value over these 10,000 blocks (~34 hours). 

## Checklist before merging
- [ x ] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [ x ] Installed and ran pre-commit hooks
- [ x ] All tests pass with `./mev test`
