### PR TITLE
check that swaps involve both pool assets

### DIFF
--- a/mev_inspect/classifiers/helpers.py
+++ b/mev_inspect/classifiers/helpers.py
@@ -94,6 +94,9 @@ def create_swap_from_pool_transfers(
     transfer_in = transfers_to_pool[-1]
     transfer_out = transfers_from_pool_to_recipient[0]
 
+    if transfer_in.token_address == transfer_out.token_address:
+        return None
+
     return Swap(
         abi_name=trace.abi_name,
         transaction_hash=trace.transaction_hash,


### PR DESCRIPTION
## What does this PR do?

When creating swaps, this PR adds a check that the swap involves two different assets. If the two assets in the swap are the same, then the swap is invalid and is discarded.

## Related issue

[327](https://github.com/flashbots/mev-inspect-py/issues/327)

## Testing

I have verified that transaction [0xd0bc1728db3e6cbe2769c2f534a5f7a9a5a46b13428c1a3f39c18dfce0154ec1](https://etherscan.io/tx/0xd0bc1728db3e6cbe2769c2f534a5f7a9a5a46b13428c1a3f39c18dfce0154ec1) processes successfully after applying this change.

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
