### PR TITLE
exclude reverted punk bid acceptances

### DIFF
--- a/mev_inspect/punks.py
+++ b/mev_inspect/punks.py
@@ -74,7 +74,10 @@ def _get_punk_bid_acceptances_for_transaction(
         if not isinstance(trace, DecodedCallTrace):
             continue
 
-        elif trace.classification == Classification.punk_accept_bid:
+        elif (
+            trace.classification == Classification.punk_accept_bid
+            and trace.error is None
+        ):
             punk_accept_bid = PunkBidAcceptance(
                 block_number=trace.block_number,
                 transaction_hash=trace.transaction_hash,


### PR DESCRIPTION
## What does this PR do?

Excludes punk bid acceptance traces with errors from punk snipe processing.

## Related issue

[329](https://github.com/flashbots/mev-inspect-py/issues/329)

## Testing

Block 13690822 now processes successfully with a single punk snipe identified (no more duplicate).

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
