### PR TITLE
FIX: Avoid CoinGecko's API rate limit with time delays, when updating prices

### DIFF
--- a/mev_inspect/prices.py
+++ b/mev_inspect/prices.py
@@ -1,16 +1,20 @@
 from datetime import datetime
 from typing import List
+import time
 
 from pycoingecko import CoinGeckoAPI
 
 from mev_inspect.schemas.prices import COINGECKO_ID_BY_ADDRESS, TOKEN_ADDRESSES, Price
 
+SLEEP_TIME = 10
 
 def fetch_prices() -> List[Price]:
     coingecko_api = CoinGeckoAPI()
     prices = []
 
     for token_address in TOKEN_ADDRESSES:
+        # Avoid Coingecko's API rate limits
+        time.sleep(SLEEP_TIME)
         coingecko_price_data = coingecko_api.get_coin_market_chart_by_id(
             id=COINGECKO_ID_BY_ADDRESS[token_address],
             vs_currency="usd",


### PR DESCRIPTION
Updating token prices with ./mev prices fetch-all can fail due to CoinGecko's API rate limits https://www.coingecko.com/en/api/pricing_2 (10-30 requests a minute)

Error message:
ValueError: {'status': {'error_code': 429, 'error_message': "You've exceeded the Rate Limit. Please visit https://www.coingecko.com/en/api/pricing to subscribe to our API plans for higher rate limits."}}

Currently, TOKEN_ADDRESSES length is 14 which can (and does) fail the function, depending on the dynamic limit

By introducing time delays between API queries we can avoid hitting the limit and failing the price update.

## What does this PR do?

A short description of what the PR does.

## Related issue

Link to the issue this PR addresses.

If there isn't already an open issue, create an issue first. This will be our home for discussing the problem itself.

## Testing

What testing was performed to verify this works? Unit tests are a big plus!

## Checklist before merging
- [ ] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [ ] Installed and ran pre-commit hooks
- [ ] All tests pass with `./mev test`
