### PR TITLE
FIX: Incorrect command to delete database data

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ tilt down
 Delete it with:
 
 ```
-kubectl delete pvc data-postgresql-postgresql-0
+kubectl delete pvc data-postgresql-0
 ```
 
 Start back up again:


### PR DESCRIPTION
The correct command is 
kubectl delete pvc data-postgresql-0

You can check the correct name with 
kubectl get pvc

## What does this PR do?

A short description of what the PR does.

## Related issue

Link to the issue this PR addresses.

If there isn't already an open issue, create an issue first. This will be our home for discussing the problem itself.

## Testing

What testing was performed to verify this works? Unit tests are a big plus!

## Checklist before merging
- [ ] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [ ] Installed and ran pre-commit hooks
- [ ] All tests pass with `./mev test`
