### PR TITLE
docs: replace pokt as suggested rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Set an environment variable `RPC_URL` to an RPC for fetching blocks.
 
 mev-inspect-py currently requires a node with support for Erigon traces and receipts (not geth yet 😔).
 
-[pokt.network](https://www.pokt.network/)'s "Ethereum Mainnet Archival with trace calls" is a good hosted option.
+[ANKR](https://www.ankr.com/)'s "Ethereum Archive" is a good hosted option.
 
 Example:
 


### PR DESCRIPTION
## What does this PR do?

POKT network is not a reliable RPC for mev-inspect.
Hence, this pr changes the RPC from POKT to one I have tested to be working, that being ANKR.

## Related issue

https://github.com/flashbots/mev-inspect-py/issues/319

## Testing

mev-inspect-block returns valid data using ankr rpcs.

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
