### PR TITLE
fix: pre-commit run --all-files

### DIFF
--- a/mev_inspect/schemas/blocks.py
+++ b/mev_inspect/schemas/blocks.py
@@ -13,7 +13,7 @@ class CallResult(CamelModel):
     gas_used: int
 
     @validator("gas_used", pre=True)
-    def maybe_hex_to_int(v):
+    def maybe_hex_to_int(cls, v):
         if isinstance(v, str):
             return hex_to_int(v)
         return v
@@ -27,7 +27,7 @@ class CallAction(Web3Model):
     gas: int
 
     @validator("value", "gas", pre=True)
-    def maybe_hex_to_int(v):
+    def maybe_hex_to_int(cls, v):
         if isinstance(v, str):
             return hex_to_int(v)
         return v

--- a/mev_inspect/schemas/receipts.py
+++ b/mev_inspect/schemas/receipts.py
@@ -24,7 +24,7 @@ class Receipt(CamelModel):
         "cumulative_gas_used",
         pre=True,
     )
-    def maybe_hex_to_int(v):
+    def maybe_hex_to_int(cls, v):
         if isinstance(v, str):
             return hex_to_int(v)
         return v

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,6 @@ import json
 import os
 from typing import Dict, List
 
-from pydantic import parse_file_as
-
 from mev_inspect.schemas.blocks import Block
 from mev_inspect.schemas.sandwiches import Sandwich
 
@@ -14,7 +12,10 @@ TEST_SANDWICHES_DIRECTORY = os.path.join(THIS_FILE_DIRECTORY, "sandwiches")
 
 def load_test_sandwiches(block_number: int) -> List[Sandwich]:
     sandwiches_path = f"{TEST_SANDWICHES_DIRECTORY}/{block_number}.json"
-    return parse_file_as(List[Sandwich], sandwiches_path)
+
+    with open(sandwiches_path, "r") as file:
+        sandwiches_data = json.load(file)
+    return [Sandwich(**sandwich) for sandwich in sandwiches_data]
 
 
 def load_test_block(block_number: int) -> Block:


### PR DESCRIPTION
## What does this PR do?

Edit testing so that `pre-commit run --all-files` runs successfully.  

## Related issue

[Link to the issue this PR addresses.](https://github.com/flashbots/mev-inspect-py/issues/340)

## Testing

Running locally. I will merge this PR to https://github.com/flashbots/mev-inspect-py/pull/339 to test the workflow, too 

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
